### PR TITLE
small output fix for /github me command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -134,7 +134,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error getting your GitHub profile."), nil
 		}
 
-		text := fmt.Sprintf("You are connected to GitHub as:\n# [![image](%s =40x40) [%s](%s)](%s)", gitUser.GetAvatarURL(), gitUser.GetLogin(), gitUser.GetHTMLURL(), gitUser.GetHTMLURL())
+		text := fmt.Sprintf("You are connected to GitHub as:\n# [![image](%s =40x40)](%s) [%s](%s)", gitUser.GetAvatarURL(), gitUser.GetHTMLURL(), gitUser.GetLogin(), gitUser.GetHTMLURL())
 		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
 	case "help":
 		text := "###### Mattermost GitHub Plugin - Slash Command Help\n" + strings.Replace(COMMAND_HELP, "|", "`", -1)


### PR DESCRIPTION
in the `/github me` instead of seeing this output with the underline in the middle of the image and the text: 

![screen shot 2018-07-30 at 15 58 25](https://user-images.githubusercontent.com/4115580/43401833-75d0280c-9411-11e8-87dc-25f198889ea4.png)

we can have this:
![screen shot 2018-07-30 at 15 59 30](https://user-images.githubusercontent.com/4115580/43401891-95b247e0-9411-11e8-8d37-2ad54fa15774.png)
