### PR TITLE
Proposed README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Use `make dist` to build distributions of the plugin that you can upload to a Ma
 Use `make check-style` to check the style.
 
 Use `make localdeploy` to deploy the plugin to your local server. You will need to restart the server to get the changes.
+
+## Notes 
+
+- This plug-in was originally developed for the Mattermost 2018 hackathon using the new plug-in architecture introduced in Mattermost 5.


### PR DESCRIPTION
Updated description of project and propose moving Hackathon mention to the bottom, rather than having it at the top, to increase trust level in the plug-in--we can acknowledge this was first developed in a Hackathon, but now it's a standard plug-in.