### PR TITLE
MM-13841 Fetch GitHub user on profile popover open

### DIFF
--- a/webapp/src/action_types/index.js
+++ b/webapp/src/action_types/index.js
@@ -5,4 +5,5 @@ export default {
     RECEIVED_MENTIONS: 'received_mentions',
     RECEIVED_UNREADS: 'received_unreads',
     RECEIVED_CONNECTED: 'received_connected',
+    RECEIVED_GITHUB_USER: 'received_github_user',
 };

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -29,6 +29,10 @@ export default class Client {
         return this.doGet(`${this.url}/unreads`);
     }
 
+    getGitHubUser = async (userID) => {
+        return this.doPost(`${this.url}/user`, {user_id: userID});
+    }
+
     doGet = async (url, body, headers = {}) => {
         headers['X-Requested-With'] = 'XMLHttpRequest';
         headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();

--- a/webapp/src/components/user_attribute/index.js
+++ b/webapp/src/components/user_attribute/index.js
@@ -1,21 +1,26 @@
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 
-import {getUser} from 'mattermost-redux/selectors/entities/users';
+import {getGitHubUser} from '../../actions';
 
 import UserAttribute from './user_attribute.jsx';
 
 function mapStateToProps(state, ownProps) {
     const id = ownProps.user ? ownProps.user.id : '';
-    const user = getUser(state, id);
-
-    let username;
-    if (user && user.props) {
-        username = user.props.git_user;
-    }
+    const user = state['plugins-github'].githubUsers[id] || {};
 
     return {
-        username,
+        id,
+        username: user.username,
     };
 }
 
-export default connect(mapStateToProps)(UserAttribute);
+function mapDispatchToProps(dispatch) {
+    return {
+        actions: bindActionCreators({
+            getGitHubUser,
+        }, dispatch),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserAttribute);

--- a/webapp/src/components/user_attribute/user_attribute.jsx
+++ b/webapp/src/components/user_attribute/user_attribute.jsx
@@ -3,8 +3,17 @@ import PropTypes from 'prop-types';
 
 export default class UserAttribute extends React.PureComponent {
     static propTypes = {
+        id: PropTypes.string.isRequired,
         username: PropTypes.string,
+        actions: PropTypes.shape({
+            getGitHubUser: PropTypes.func.isRequired,
+        }).isRequired,
     };
+
+    constructor(props) {
+        super(props);
+        props.actions.getGitHubUser(props.id);
+    }
 
     render() {
         const username = this.props.username;

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -108,6 +108,18 @@ function unreads(state = [], action) {
     }
 }
 
+function githubUsers(state = {}, action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_GITHUB_USER: {
+        const nextState = {...state};
+        nextState[action.userID] = action.data;
+        return nextState;
+    }
+    default:
+        return state;
+    }
+}
+
 export default combineReducers({
     connected,
     enterpriseURL,
@@ -120,4 +132,5 @@ export default combineReducers({
     yourAssignments,
     mentions,
     unreads,
+    githubUsers,
 });


### PR DESCRIPTION
Switched from populating the user's GitHub username from props to a dedicated fetch in the profile popover.

There's no tests because none of the framework for testing the server API or clients has been set up for this plugin.

https://mattermost.atlassian.net/browse/MM-13841