### PR TITLE
Send message to users that need to reconnect to access private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ __If you're using GitHub Enterprise, replace all GitHub links below with your Gi
     2. Save the settings
 4. (Optional) Lock the plugin to a GitHub organization
     * Go to System Console -> Plugins -> GitHub and set the GitHub Organization field to the name of your GitHub organization
+4. (Optional) Enable private repositories
+    * Go to System Console -> Plugins -> GitHub and set Enable Private Repositories to true
+    * Note that if you do this after users have already connected their accounts to GitHub they will need to disconnect and reconnect their accounts to be able to use private repositories
 4. (Enterprise only) Set your Enterprise URLs
     * Go to System Console -> Plugins -> GitHub and set the Enterprise Base URL and Enterprise Upload URL fields to your GitHub Enterprise URLs, ex: `https://github.example.com`
     * The Base and Upload URLs are often the same

--- a/plugin.json
+++ b/plugin.json
@@ -66,9 +66,9 @@
             },
             {
                 "key": "EnablePrivateRepo",
-                "display_name": "Enable private repositories",
+                "display_name": "Enable Private Repositories",
                 "type": "bool",
-                "help_text": "(Optional) make it possible to enable private repositories as well. Existing users should re-grant their access to plugin."
+                "help_text": "(Optional) Allow the plugin to work with private repositories. Enabling private repositories will require existing users to reconnect their accounts to gain access to private repositories. A message will be automatically be sent to affected users next time they load Mattermost alerting them of this."
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."

--- a/server/api.go
+++ b/server/api.go
@@ -145,6 +145,7 @@ func (p *Plugin) completeConnectUserToGitHub(w http.ResponseWriter, r *http.Requ
 			DailyReminder:  true,
 			Notifications:  true,
 		},
+		AllowedPrivateRepos: config.EnablePrivateRepo,
 	}
 
 	if err := p.storeGitHubUserInfo(userInfo); err != nil {
@@ -301,6 +302,23 @@ func (p *Plugin) getConnected(w http.ResponseWriter, r *http.Request) {
 				p.PostToDo(info)
 				info.LastToDoPostAt = now
 				p.storeGitHubUserInfo(info)
+			}
+		}
+
+		privateRepoStoreKey := info.UserID + GITHUB_PRIVATE_REPO_KEY
+		if config.EnablePrivateRepo && !info.AllowedPrivateRepos {
+			hasBeenNotified := false
+			if val, err := p.API.KVGet(privateRepoStoreKey); err == nil {
+				hasBeenNotified = val != nil
+			} else {
+				mlog.Error("Unable to get private repo key value, err=" + err.Error())
+			}
+
+			if !hasBeenNotified {
+				p.CreateBotDMPost(info.UserID, "Private repositories have been enabled for this plugin. To be able to use them you must disconnect and reconnect your GitHub account. To reconnect your account, use the following slash commands: `/github disconnect` followed by `/github connect`.", "")
+				if err := p.API.KVSet(privateRepoStoreKey, []byte("1")); err != nil {
+					mlog.Error("Unable to set private repo key value, err=" + err.Error())
+				}
 			}
 		}
 	}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,6 +22,7 @@ const (
 	GITHUB_TOKEN_KEY        = "_githubtoken"
 	GITHUB_STATE_KEY        = "_githubstate"
 	GITHUB_USERNAME_KEY     = "_githubusername"
+	GITHUB_PRIVATE_REPO_KEY = "_githubprivate"
 	WS_EVENT_CONNECT        = "connect"
 	WS_EVENT_DISCONNECT     = "disconnect"
 	WS_EVENT_REFRESH        = "refresh"
@@ -121,11 +122,12 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 }
 
 type GitHubUserInfo struct {
-	UserID         string
-	Token          *oauth2.Token
-	GitHubUsername string
-	LastToDoPostAt int64
-	Settings       *UserSettings
+	UserID              string
+	Token               *oauth2.Token
+	GitHubUsername      string
+	LastToDoPostAt      int64
+	Settings            *UserSettings
+	AllowedPrivateRepos bool
 }
 
 type UserSettings struct {


### PR DESCRIPTION
This is a follow-up to #40 to send a message to users who had previously connected to the GitHub plugin, letting them know to reconnect their accounts to use private repos.

I also updated the README and the setting help text.

FYI @zetaab 