### PR TITLE
Fix profile hover url when enterprise url is set

### DIFF
--- a/webapp/src/components/user_attribute/index.js
+++ b/webapp/src/components/user_attribute/index.js
@@ -12,6 +12,7 @@ function mapStateToProps(state, ownProps) {
     return {
         id,
         username: user.username,
+        enterpriseURL: state['plugins-github'].enterpriseURL,
     };
 }
 

--- a/webapp/src/components/user_attribute/user_attribute.jsx
+++ b/webapp/src/components/user_attribute/user_attribute.jsx
@@ -17,6 +17,10 @@ export default class UserAttribute extends React.PureComponent {
 
     render() {
         const username = this.props.username;
+        let baseURL = 'https://github.com';
+        if (this.props.enterpriseURL) {
+            baseURL = this.props.enterpriseURL;
+        }
 
         if (!username) {
             return null;
@@ -25,7 +29,7 @@ export default class UserAttribute extends React.PureComponent {
         return (
             <div style={style.container}>
                 <a
-                    href={'https://github.com/' + username}
+                    href={baseURL + '/' + username}
                     target='_blank'
                     rel='noopener noreferrer'
                 >

--- a/webapp/src/components/user_attribute/user_attribute.jsx
+++ b/webapp/src/components/user_attribute/user_attribute.jsx
@@ -5,6 +5,7 @@ export default class UserAttribute extends React.PureComponent {
     static propTypes = {
         id: PropTypes.string.isRequired,
         username: PropTypes.string,
+        enterpriseURL: PropTypes.string,
         actions: PropTypes.shape({
             getGitHubUser: PropTypes.func.isRequired,
         }).isRequired,


### PR DESCRIPTION
Url shown in profile hover always points to github.com/\<username\> instead of \<enterprise-url\>/\<username\>
This fixes the url to point to correct address

Fixes #42 