### PR TITLE
make Github icon url configurable

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -69,6 +69,12 @@
                 "display_name": "Enable Private Repositories",
                 "type": "bool",
                 "help_text": "(Optional) Allow the plugin to work with private repositories. Enabling private repositories will require existing users to reconnect their accounts to gain access to private repositories. A message will be automatically be sent to affected users next time they load Mattermost alerting them of this."
+            },
+            {
+                "key": "GithubIconURL",
+                "display_name": "Github bot icon URL",
+                "type": "text",
+                "help_text": "(Optional) The URL to github bot icon URL."
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."

--- a/server/api.go
+++ b/server/api.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	API_ERROR_ID_NOT_CONNECTED = "not_connected"
-	GITHUB_ICON_URL            = "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
 	GITHUB_USERNAME            = "GitHub Plugin"
 )
 
@@ -33,6 +32,14 @@ func writeAPIError(w http.ResponseWriter, err *APIErrorResponse) {
 	b, _ := json.Marshal(err)
 	w.WriteHeader(err.StatusCode)
 	w.Write(b)
+}
+
+func (p *Plugin) GetIconURL() string {
+	config := p.getConfiguration()
+	if config.GithubIconURL != "" {
+		return config.GithubIconURL
+	}
+	return "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
 }
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {

--- a/server/command.go
+++ b/server/command.go
@@ -45,12 +45,12 @@ func getCommand() *model.Command {
 	}
 }
 
-func getCommandResponse(responseType, text string) *model.CommandResponse {
+func getCommandResponse(p *Plugin, responseType, text string) *model.CommandResponse {
 	return &model.CommandResponse{
 		ResponseType: responseType,
 		Text:         text,
 		Username:     GITHUB_USERNAME,
-		IconURL:      GITHUB_ICON_URL,
+		IconURL:      p.GetIconURL(),
 		Type:         model.POST_DEFAULT,
 	}
 }
@@ -74,10 +74,10 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	if action == "connect" {
 		config := p.API.GetConfig()
 		if config.ServiceSettings.SiteURL == nil {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error connecting to GitHub."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error connecting to GitHub."), nil
 		}
 
-		resp := getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("[Click here to link your GitHub account.](%s/plugins/github/oauth/connect)", *config.ServiceSettings.SiteURL))
+		resp := getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("[Click here to link your GitHub account.](%s/plugins/github/oauth/connect)", *config.ServiceSettings.SiteURL))
 		return resp, nil
 	}
 
@@ -90,7 +90,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		if apiErr.ID == API_ERROR_ID_NOT_CONNECTED {
 			text = "You must connect your account to GitHub first. Either click on the GitHub logo in the bottom left of the screen or enter `/github connect`."
 		}
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
 	}
 
 	githubClient = p.githubConnect(*info.Token)
@@ -102,11 +102,11 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 
 		txt := ""
 		if len(parameters) == 0 {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Please specify a repository or 'list' command."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Please specify a repository or 'list' command."), nil
 		} else if len(parameters) == 1 && parameters[0] == "list" {
 			subs, err := p.GetSubscriptionsByChannel(args.ChannelId)
 			if err != nil {
-				return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, err.Error()), nil
+				return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, err.Error()), nil
 			}
 
 			if len(subs) == 0 {
@@ -117,7 +117,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			for _, sub := range subs {
 				txt += fmt.Sprintf("* `%s` - %s\n", sub.Repository, sub.Features)
 			}
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, txt), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, txt), nil
 		} else if len(parameters) > 1 {
 			features = strings.Join(parameters[1:], " ")
 		}
@@ -125,62 +125,62 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		_, owner, repo := parseOwnerAndRepo(parameters[0], config.EnterpriseBaseURL)
 		if repo == "" {
 			if err := p.SubscribeOrg(context.Background(), githubClient, args.UserId, owner, args.ChannelId, features); err != nil {
-				return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, err.Error()), nil
+				return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, err.Error()), nil
 			}
 
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Successfully subscribed to organization %s.", owner)), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Successfully subscribed to organization %s.", owner)), nil
 		}
 
 		if err := p.Subscribe(context.Background(), githubClient, args.UserId, owner, repo, args.ChannelId, features); err != nil {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, err.Error()), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, err.Error()), nil
 		}
 
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Successfully subscribed to %s.", repo)), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Successfully subscribed to %s.", repo)), nil
 	case "unsubscribe":
 		if len(parameters) == 0 {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Please specify a repository."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Please specify a repository."), nil
 		}
 
 		repo := parameters[0]
 
 		if err := p.Unsubscribe(args.ChannelId, repo); err != nil {
 			mlog.Error(err.Error())
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error trying to unsubscribe. Please try again."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error trying to unsubscribe. Please try again."), nil
 		}
 
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Succesfully unsubscribed from %s.", repo)), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, fmt.Sprintf("Succesfully unsubscribed from %s.", repo)), nil
 	case "disconnect":
 		p.disconnectGitHubAccount(args.UserId)
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Disconnected your GitHub account."), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Disconnected your GitHub account."), nil
 	case "todo":
 		text, err := p.GetToDo(ctx, info.GitHubUsername, githubClient)
 		if err != nil {
 			mlog.Error(err.Error())
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error getting your to do items."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error getting your to do items."), nil
 		}
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
 	case "me":
 		gitUser, _, err := githubClient.Users.Get(ctx, "")
 		if err != nil {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error getting your GitHub profile."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Encountered an error getting your GitHub profile."), nil
 		}
 
 		text := fmt.Sprintf("You are connected to GitHub as:\n# [![image](%s =40x40)](%s) [%s](%s)", gitUser.GetAvatarURL(), gitUser.GetHTMLURL(), gitUser.GetLogin(), gitUser.GetHTMLURL())
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
 	case "help":
 		text := "###### Mattermost GitHub Plugin - Slash Command Help\n" + strings.Replace(COMMAND_HELP, "|", "`", -1)
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
 	case "":
 		text := "###### Mattermost GitHub Plugin - Slash Command Help\n" + strings.Replace(COMMAND_HELP, "|", "`", -1)
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, text), nil
 	case "settings":
 		if len(parameters) < 2 {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Please specify both a setting and value. Use `/github help` for more usage information."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Please specify both a setting and value. Use `/github help` for more usage information."), nil
 		}
 
 		setting := parameters[0]
 		if setting != SETTING_NOTIFICATIONS && setting != SETTING_REMINDERS {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Unknown setting."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Unknown setting."), nil
 		}
 
 		strValue := parameters[1]
@@ -188,7 +188,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		if strValue == SETTING_ON {
 			value = true
 		} else if strValue != SETTING_OFF {
-			return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Invalid value. Accepted values are: \"on\" or \"off\"."), nil
+			return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Invalid value. Accepted values are: \"on\" or \"off\"."), nil
 		}
 
 		if setting == SETTING_NOTIFICATIONS {
@@ -205,7 +205,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 
 		p.storeGitHubUserInfo(info)
 
-		return getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Settings updated."), nil
+		return getCommandResponse(p, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, "Settings updated."), nil
 	}
 
 	return &model.CommandResponse{}, nil

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,7 @@ type configuration struct {
 	EncryptionKey           string
 	EnterpriseBaseURL       string
 	EnterpriseUploadURL     string
+	GithubIconURL           string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -228,7 +228,7 @@ func (p *Plugin) CreateBotDMPost(userID, message, postType string) *model.AppErr
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -217,7 +217,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 
@@ -309,7 +309,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 
@@ -400,7 +400,7 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 		Message: newPushMessage,
 	}
@@ -452,7 +452,7 @@ func (p *Plugin) postCreateEvent(event *github.CreateEvent) {
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 		Message: newCreateMessage,
 	}
@@ -504,7 +504,7 @@ func (p *Plugin) postDeleteEvent(event *github.DeleteEvent) {
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 		Message: newDeleteMessage,
 	}
@@ -559,7 +559,7 @@ func (p *Plugin) postIssueCommentEvent(event *github.IssueCommentEvent) {
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 
@@ -641,7 +641,7 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 
@@ -702,7 +702,7 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 
@@ -755,7 +755,7 @@ func (p *Plugin) handleCommentMentionNotification(event *github.IssueCommentEven
 		Props: map[string]interface{}{
 			"from_webhook":      "true",
 			"override_username": GITHUB_USERNAME,
-			"override_icon_url": GITHUB_ICON_URL,
+			"override_icon_url": p.GetIconURL(),
 		},
 	}
 


### PR DESCRIPTION
I installed 0.8 version today our mattermost, and now the problem is that Icon is not visible at all. This is because icon url is hardcoded to code, and our mattermost server cannot access to internet.

That is why I suggest that we make this url configurable