### PR TITLE
Update organization subscription implementation

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -16,8 +16,7 @@ const COMMAND_HELP = `* |/github connect| - Connect your Mattermost account to y
 * |/github disconnect| - Disconnect your Mattermost account from your GitHub account
 * |/github todo| - Get a list of unread messages and pull requests awaiting your review
 * |/github subscribe list| - Will list the current channel subscriptions
-* |/github subscribe owner [features]| - Subscribe the current channel to all available repositories within an organization and receive notifications about opened pull requests and issues
-* |/github subscribe owner/repo [features]| - Subscribe the current channel to receive notifications about opened pull requests and issues for a repository
+* |/github subscribe owner[/repo] [features]| - Subscribe the current channel to receive notifications about opened pull requests and issues for an organization or repository
   * |features| is a comma-delimited list of one or more the following:
     * issues - includes new and closed issues
 	* pulls - includes new and closed pull requests
@@ -115,7 +114,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 				txt = "### Subscriptions in this channel\n"
 			}
 			for _, sub := range subs {
-				txt += fmt.Sprintf("* `%s` - %s\n", sub.Repository, sub.Features)
+				txt += fmt.Sprintf("* `%s` - %s\n", strings.Trim(sub.Repository, "/"), sub.Features)
 			}
 			return p.getCommandResponse(model.COMMAND_RESPONSE_TYPE_EPHEMERAL, txt), nil
 		} else if len(parameters) > 1 {

--- a/server/utils.go
+++ b/server/utils.go
@@ -112,7 +112,7 @@ func parseOwnerAndRepo(full, baseURL string) (string, string, string) {
 
 	if len(splitStr) == 1 {
 		owner := splitStr[0]
-		return fmt.Sprintf("%s", owner), owner, ""
+		return fmt.Sprintf("%s/", owner), owner, ""
 	} else if len(splitStr) != 2 {
 		return "", "", ""
 	}
@@ -157,4 +157,8 @@ func fixGithubNotificationSubjectURL(url string) string {
 	url = strings.Replace(url, "/pulls/", "/pull/", 1)
 	url = strings.Replace(url, "/api/v3", "", 1)
 	return url
+}
+
+func fullNameFromOwnerAndRepo(owner, repo string) string {
+	return fmt.Sprintf("%s/%s", owner, repo)
 }


### PR DESCRIPTION
The previous implementation would require paging through all the repositories of an organization and creating a subscription for each one, at the time the org was subscribed to. This worked OK but by just storing a single subscription for the entire org instead we can reduce a lot of what we're storing and get rid of the paging hits against the GH API.

The new implementation also has the major benefits of automatically picking up on new repositories added to the organization (since the webhook is org wide already) and not requiring unsubscribing from each and every repository when you want to unsubscribe a channel from an organization.