### PR TITLE
Clarify how to access features as end user

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub plugin for Mattermost. Supports GitHub SaaS and Enterprise versions.
 
 ## Features
 
-After your System Admin has [configured the GitHub plugin](#Configuration), run `/jira connect` in a Mattermost channel to connect your Mattermost and GitHub accounts.
+After your System Admin has [configured the GitHub plugin](#Configuration), run `/github connect` in a Mattermost channel to connect your Mattermost and GitHub accounts.
 
 Once connected, you'll have access to the following features:
 
@@ -24,8 +24,6 @@ Once connected, you'll have access to the following features:
     * __Get to do items__ - Use `/github todo` to get an ephemeral message with items to do in GitHub, including a list of unread messages and pull requests awaiting your review
     * __Update settings__ - Use `/github settings` to update your settings for notifications and daily reminders
     * __And more!__ - Run `/github help` to see what else the slash command can do
-
-To use any of the above features, first connect your Mattermost account to your GitHub account with `/github connect`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A GitHub plugin for Mattermost. Supports GitHub SaaS and Enterprise versions.
 
 ## Features
 
+After your System Admin has [configured the GitHub plugin](#Configuration), run `/jira connect` in a Mattermost channel to connect your Mattermost and GitHub accounts.
+
+Once connected, you'll have access to the following features:
+
 * __Daily reminders__ - the first time you log in to Mattermost each day, get a post letting you know what issues and pull requests need your attention
 * __Notifications__ - get a direct message in Mattermost when someone mentions you, requests your review, comments on or modifies one of your pull requests/issues, or assigns you on GitHub
 * __Sidebar buttons__ - stay up-to-date with how many reviews, unread messages, assignments and open pull requests you have with buttons in the Mattermost sidebar
@@ -125,10 +129,10 @@ Set up your GitHub webhook from the repository instead of the organization. Noti
 
 The reminder and `/github todo` will still search the whole organization, but only list items assigned to you.
 
-## How do I share feedback on this plugin?
+### How do I share feedback on this plugin?
 
 Feel free to create a GitHub issue or [join the GitHub Plugin channel on our community Mattermost instance](https://pre-release.mattermost.com/core/channels/github-plugin) to discuss.
 
-## How does the plugin save user data for each connected GitHub user?
+### How does the plugin save user data for each connected GitHub user?
 
 GitHub user tokens are AES encrypted with an At Rest Encryption Key configured in the plugin's settings page. Once encrypted, the tokens are saved in the `PluginKeyValueStore` table in your Mattermost database.


### PR DESCRIPTION
1. Add note about connecting your account to access features as an end user
   - Feedback on how to make this more obvious is welcome
2. Fix section headers in FAQ