### PR TITLE
GH-90 Added checking for updates before sending daily update

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -296,7 +296,7 @@ func (p *Plugin) getConnected(w http.ResponseWriter, r *http.Request) {
 		resp.GitHubClientID = config.GitHubOAuthClientID
 		resp.Settings = info.Settings
 
-		if info.Settings.DailyReminder && r.URL.Query().Get("reminder") == "true" {
+		if info.Settings.DailyReminder && r.URL.Query().Get("reminder") == "true" && p.HasNews(info) {
 			lastPostAt := info.LastToDoPostAt
 
 			var timezone *time.Location

--- a/server/api.go
+++ b/server/api.go
@@ -296,7 +296,7 @@ func (p *Plugin) getConnected(w http.ResponseWriter, r *http.Request) {
 		resp.GitHubClientID = config.GitHubOAuthClientID
 		resp.Settings = info.Settings
 
-		if info.Settings.DailyReminder && r.URL.Query().Get("reminder") == "true" && p.HasNews(info) {
+		if info.Settings.DailyReminder && r.URL.Query().Get("reminder") == "true" {
 			lastPostAt := info.LastToDoPostAt
 
 			var timezone *time.Location
@@ -308,9 +308,11 @@ func (p *Plugin) getConnected(w http.ResponseWriter, r *http.Request) {
 			nt := time.Unix(now/1000, 0).In(timezone)
 			lt := time.Unix(lastPostAt/1000, 0).In(timezone)
 			if nt.Sub(lt).Hours() >= 1 && (nt.Day() != lt.Day() || nt.Month() != lt.Month() || nt.Year() != lt.Year()) {
-				p.PostToDo(info)
-				info.LastToDoPostAt = now
-				p.storeGitHubUserInfo(info)
+				if p.HasUnreads(info) {
+					p.PostToDo(info)
+					info.LastToDoPostAt = now
+					p.storeGitHubUserInfo(info)
+				}
 			}
 		}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -367,7 +367,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 	return text, nil
 }
 
-func (p *Plugin) HasNews(info *GitHubUserInfo) bool {
+func (p *Plugin) HasUnreads(info *GitHubUserInfo) bool {
 	username := info.GitHubUsername
 	ctx := context.Background()
 	githubClient := p.githubConnect(*info.Token)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -376,26 +376,22 @@ func (p *Plugin) HasUnreads(info *GitHubUserInfo) bool {
 	issues, _, err := githubClient.Search.Issues(ctx, getReviewSearchQuery(username, config.GitHubOrg), &github.SearchOptions{})
 	if err != nil {
 		mlog.Error(err.Error())
-		return false
 	}
 
 	yourPrs, _, err := githubClient.Search.Issues(ctx, getYourPrsSearchQuery(username, config.GitHubOrg), &github.SearchOptions{})
 	if err != nil {
 		mlog.Error(err.Error())
-		return false
 	}
 
 	yourAssignments, _, err := githubClient.Search.Issues(ctx, getYourAssigneeSearchQuery(username, config.GitHubOrg), &github.SearchOptions{})
 	if err != nil {
 		mlog.Error(err.Error())
-		return false
 	}
 
 	relevantNotifications := false
 	notifications, _, err := githubClient.Activity.ListNotifications(ctx, &github.NotificationListOptions{})
 	if err != nil {
 		mlog.Error(err.Error())
-		return false
 	}
 
 	for _, n := range notifications {
@@ -416,7 +412,7 @@ func (p *Plugin) HasUnreads(info *GitHubUserInfo) bool {
 		break
 	}
 
-	if issues.GetTotal() == 0 && relevantNotifications && yourPrs.GetTotal() == 0 && yourAssignments.GetTotal() == 0 {
+	if issues.GetTotal() == 0 && !relevantNotifications && yourPrs.GetTotal() == 0 && yourAssignments.GetTotal() == 0 {
 		return false
 	}
 


### PR DESCRIPTION
Issue : #90

Current:
Currently the daily reminder is always send even if there is nothing the user has missed. 

PR: 
Adds a check before sending the daily update. Now there either has to be an unread message, a pull request needing reviewing, an open pull request or a new assignment. 
If nothing is found to report there will be no daily update. 




