### PR TITLE
extend fixGithubNotificationSubjectURL to commits

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -155,6 +155,7 @@ func fixGithubNotificationSubjectURL(url string) string {
 	url = strings.Replace(url, "api.", "", 1)
 	url = strings.Replace(url, "repos/", "", 1)
 	url = strings.Replace(url, "/pulls/", "/pull/", 1)
+	url = strings.Replace(url, "/commits/", "/commit/", 1)
 	url = strings.Replace(url, "/api/v3", "", 1)
 	return url
 }

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -43,6 +43,7 @@ func TestFixGithubNotificationSubjectURL(t *testing.T) {
 		{Text: "https://api.github.com/repos/jwilander/mattermost-webapp/pulls/123", Expected: "https://github.com/jwilander/mattermost-webapp/pull/123"},
 		{Text: "https://enterprise.github.com/api/v3/jwilander/mattermost-webapp/issues/123", Expected: "https://enterprise.github.com/jwilander/mattermost-webapp/issues/123"},
 		{Text: "https://enterprise.github.com/api/v3/jwilander/mattermost-webapp/pull/123", Expected: "https://enterprise.github.com/jwilander/mattermost-webapp/pull/123"},
+		{Text: "https://api.github.com/repos/mattermost/mattermost-server/commits/cc6c385d3e8903546fc6fc856bf468ad09b70913", Expected: "https://github.com/mattermost/mattermost-server/commit/cc6c385d3e8903546fc6fc856bf468ad09b70913"},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
I've had a notification sitting unread for a while that linked out to https://github.com/mattermost/mattermost-server/commits/cc6c385d3e8903546fc6fc856bf468ad09b70913, but never marked the notification as read. Digging through the code, I discovered `fixGithubNotificationSubjectURL` and the need to do the same for `/commits/`. Tested locally, which fixed my notification issue, then added that very notification as a test case.