### PR TITLE
Update GitHub plugin introduction with authorization callback URL

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -15,7 +15,7 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "To set up the GitHub plugin, you need to register a GitHub OAuth app here https://github.com/settings/applications/new.",
+        "header": "To set up the GitHub plugin, [register a GitHub OAuth app](https://github.com/settings/applications/new) with `https://your-mattermost-url.com/plugins/github/oauth/complete` as your Authorization callback URL.",
         "settings": [
             {
                 "key": "GitHubOAuthClientID",


### PR DESCRIPTION
In response to https://github.com/mattermost/mattermost-plugin-github/issues/94

@aaronrothschild would be curious to hear your thoughts on other options, e.g. we could link to docs from the Introduction page, or incorporate some of the steps directly in there.