### PR TITLE
link notifications in rhs

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -410,7 +410,7 @@ func (p *Plugin) getUnreads(w http.ResponseWriter, r *http.Request) {
 
 		filteredNotifications = append(filteredNotifications, &filteredNotification{
 			Notification: *n,
-			HTMLUrl: fixGithubNotificationSubjectURL(n.GetSubject().GetURL()),
+			HTMLUrl:      fixGithubNotificationSubjectURL(n.GetSubject().GetURL()),
 		})
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -392,7 +392,13 @@ func (p *Plugin) getUnreads(w http.ResponseWriter, r *http.Request) {
 		mlog.Error(err.Error())
 	}
 
-	filteredNotifications := []*github.Notification{}
+	type filteredNotification struct {
+		github.Notification
+
+		HTMLUrl string `json:"html_url"`
+	}
+
+	filteredNotifications := []*filteredNotification{}
 	for _, n := range notifications {
 		if n.GetReason() == "subscribed" {
 			continue
@@ -402,7 +408,10 @@ func (p *Plugin) getUnreads(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		filteredNotifications = append(filteredNotifications, n)
+		filteredNotifications = append(filteredNotifications, &filteredNotification{
+			Notification: *n,
+			HTMLUrl: fixGithubNotificationSubjectURL(n.GetSubject().GetURL()),
+		})
 	}
 
 	resp, _ := json.Marshal(filteredNotifications)


### PR DESCRIPTION
Update server to send down an `html_url` for use in linking notifications in the RHS.

![image](https://user-images.githubusercontent.com/1023171/61314163-5e629300-a7d2-11e9-9675-e149aa9bca95.png)
