### PR TITLE
added titles to todo elements

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -348,7 +348,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v pull requests awaiting your review:\n", issueResults.GetTotal())
 
 		for _, pr := range issueResults.Issues {
-			text += fmt.Sprintf("* %v\n", pr.GetHTMLURL())
+			text += fmt.Sprintf("* %v - %v\n", pr.GetHTMLURL(), pr.GetTitle())
 		}
 	}
 
@@ -360,7 +360,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v open pull requests:\n", yourPrs.GetTotal())
 
 		for _, pr := range yourPrs.Issues {
-			text += fmt.Sprintf("* %v\n", pr.GetHTMLURL())
+			text += fmt.Sprintf("* %v - %v\n", pr.GetHTMLURL(), pr.GetTitle())
 		}
 	}
 
@@ -372,7 +372,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v assignments:\n", yourAssignments.GetTotal())
 
 		for _, assign := range yourAssignments.Issues {
-			text += fmt.Sprintf("* %v\n", assign.GetHTMLURL())
+			text += fmt.Sprintf("* %v - %v\n", assign.GetHTMLURL(), assign.GetTitle())
 		}
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -348,7 +348,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v pull requests awaiting your review:\n", issueResults.GetTotal())
 
 		for _, pr := range issueResults.Issues {
-			text += fmt.Sprintf("* %v - %v\n", pr.GetHTMLURL(), pr.GetTitle())
+			text += fmt.Sprintf("* [%v](%v)\n", pr.GetTitle(), pr.GetHTMLURL())
 		}
 	}
 
@@ -360,7 +360,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v open pull requests:\n", yourPrs.GetTotal())
 
 		for _, pr := range yourPrs.Issues {
-			text += fmt.Sprintf("* %v - %v\n", pr.GetHTMLURL(), pr.GetTitle())
+			text += fmt.Sprintf("* [%v](%v)\n", pr.GetTitle(), pr.GetHTMLURL())
 		}
 	}
 
@@ -372,7 +372,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v assignments:\n", yourAssignments.GetTotal())
 
 		for _, assign := range yourAssignments.Issues {
-			text += fmt.Sprintf("* %v - %v\n", assign.GetHTMLURL(), assign.GetTitle())
+			text += fmt.Sprintf("* [%v](%v)\n", assign.GetTitle(), assign.GetHTMLURL())
 		}
 	}
 


### PR DESCRIPTION
Right now, the reminder DM (or `/github todo`) shows just the URLs. This PR adds additionaly a title of the PRs and Issues , making the list easier to read.