### PR TITLE
updated webhook log when webhook type is not application/json

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -64,7 +64,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	event, err := github.ParseWebHook(github.WebHookType(r), body)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Error("GitHub webhook content type should be set to \"application/json\"", mlog.Err(err))
 		return
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -65,6 +65,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	event, err := github.ParseWebHook(github.WebHookType(r), body)
 	if err != nil {
 		mlog.Error("GitHub webhook content type should be set to \"application/json\"", mlog.Err(err))
+		http.Error(w, "wrong mime-type. should be \"application/json\"", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Provide a more clear error message when the wrong content type is selected for a webhook
- Update the server log error message to state GitHub webhook content type should be set to "application/json"
- Fail the request with a proper status code so that the webhook shows up as failed on GitHub
## Issue
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/95