### PR TITLE
MM-8880: Show code block previews of Github permalinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 govet:
 ifneq ($(HAS_SERVER),)
 	@echo Running govet
-	@# Workaroung because you can't install binaries without adding them to go.mod
+	@# Workaround because you can't install binaries without adding them to go.mod
 	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet ./server/...
 	$(GO) vet -vettool=$(GOPATH)/bin/shadow ./server/...

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 govet:
 ifneq ($(HAS_SERVER),)
 	@echo Running govet
-	@# Workaroung because you can't install binaries without adding them to go.mod 
+	@# Workaroung because you can't install binaries without adding them to go.mod
 	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet ./server/...
 	$(GO) vet -vettool=$(GOPATH)/bin/shadow ./server/...
@@ -154,7 +154,7 @@ endif
 
 ## Extract strings for translation from the source code.
 .PHONY: i18n-extract
-i18n-extract: 
+i18n-extract:
 ifneq ($(HAS_WEBAPP),)
 	@[[ -d $(MM_UTILITIES_DIR) ]] || echo "You must clone github.com/mattermost/mattermost-utilities repo in .. to use this command"
 	@[[ -d $(MM_UTILITIES_DIR) ]] && cd $(MM_UTILITIES_DIR) && npm install && npm run babel && node mmjstool/build/index.js i18n extract-webapp --webapp-dir ../mattermost-plugin-demo/webapp

--- a/plugin.json
+++ b/plugin.json
@@ -67,6 +67,12 @@
                 "display_name": "Enable Private Repositories",
                 "type": "bool",
                 "help_text": "(Optional) Allow the plugin to work with private repositories. When enabled, existing users must reconnect their accounts to gain access to private repositories. Affected users will be notified by the plugin once private repositories are enabled."
+            },
+            {
+                "key": "EnableCodePreview",
+                "display_name": "Enable Code Previews",
+                "type": "bool",
+                "help_text": "(Optional) Allow the plugin to expand permalinks to github files with an actual preview of the linked file."
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -29,6 +29,7 @@ type configuration struct {
 	EnterpriseBaseURL       string
 	EnterpriseUploadURL     string
 	PluginsDirectory        string
+	EnableCodePreview       bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/main.go
+++ b/server/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	plugin.ClientMain(&Plugin{})
+	plugin.ClientMain(New())
 }

--- a/server/main.go
+++ b/server/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	plugin.ClientMain(New())
+	plugin.ClientMain(NewPlugin())
 }

--- a/server/permalinks.go
+++ b/server/permalinks.go
@@ -105,12 +105,11 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClie
 		reqctx, cancel := context.WithTimeout(context.Background(), permalinkReqTimeout)
 		fileContent, _, _, err := ghClient.Repositories.GetContents(reqctx,
 			r.permalinkInfo.user, r.permalinkInfo.repo, r.permalinkInfo.path, &opts)
+		defer cancel()
 		if err != nil {
 			p.API.LogError("error while fetching file contents", "error", err.Error(), "path", r.permalinkInfo.path)
-			cancel()
 			continue
 		}
-		cancel()
 		// this is not a file, ignore.
 		if fileContent == nil {
 			p.API.LogWarn("permalink is not a file", "file", r.permalinkInfo.path)

--- a/server/permalinks.go
+++ b/server/permalinks.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v25/github"
+)
+
+const maxPermalinkReplacements = 10
+const permalinkReqTimeout = 2 * time.Second
+
+// replacement holds necessary info to replace github permalinks
+// in messages with a code preview block
+type replacement struct {
+	index      int               // index of the permalink in the string
+	word       string            // the permalink
+	captureMap map[string]string // named regex capture group of the link
+}
+
+// getReplacements returns the permalink replacements that needs to be performed
+// on a message.
+func (p *Plugin) getReplacements(msg string) []replacement {
+	// find the permalinks from the msg using a regex
+	matches := p.githubRegex.FindAllStringSubmatch(msg, -1)
+	indices := p.githubRegex.FindAllStringIndex(msg, -1)
+	replacements := make([]replacement, 0, maxPermalinkReplacements)
+	for i, m := range matches {
+		// have a limit on the no. of replacements to do
+		if i > maxPermalinkReplacements {
+			break
+		}
+		word := m[0]
+		index := indices[i][0]
+		r := replacement{
+			index: index,
+			word:  word,
+		}
+		// ignore if the word is inside a link
+		if isInsideLink(msg, index) {
+			continue
+		}
+		// populate the captureMap with the extracted groups of the regex
+		for j, name := range p.githubRegex.SubexpNames() {
+			if j == 0 {
+				r.captureMap = make(map[string]string)
+				continue
+			}
+			r.captureMap[name] = m[j]
+		}
+		replacements = append(replacements, r)
+	}
+	return replacements
+}
+
+// makeReplacements perform the given replacements on the msg and returns
+// the new msg.
+func (p *Plugin) makeReplacements(msg string, replacements []replacement) string {
+	for _, r := range replacements {
+		// quick bailout if the commit hash is not proper
+		_, err := hex.DecodeString(r.captureMap["commit"])
+		if err != nil {
+			p.API.LogError("bad git commit hash", "error", err.Error(), "hash", r.captureMap["commit"])
+			continue
+		}
+
+		// get the file contents
+		opts := github.RepositoryContentGetOptions{
+			Ref: r.captureMap["commit"],
+		}
+		// TODO: make all of these requests concurrently.
+		reqctx, cancel := context.WithTimeout(context.Background(), permalinkReqTimeout)
+		fileContent, _, _, err := p.githubClient.Repositories.GetContents(reqctx,
+			r.captureMap["user"], r.captureMap["repo"], r.captureMap["path"], &opts)
+		if err != nil {
+			p.API.LogError("error while fetching file contents", "error", err.Error(), "path", r.captureMap["path"])
+			cancel()
+			continue
+		}
+		cancel()
+		// this is not a file, ignore.
+		if fileContent == nil {
+			continue
+		}
+		decoded, err := fileContent.GetContent()
+		if err != nil {
+			p.API.LogError("error while decoding file contents", "error", err.Error(), "path", r.captureMap["path"])
+			continue
+		}
+
+		// get the required lines
+		start, end := getLineNumbers(r.captureMap["line"])
+		// bad anchor tag, ignore.
+		if start == -1 || end == -1 {
+			continue
+		}
+		lines := filterLines(decoded, start, end)
+
+		// construct the final string
+		final := fmt.Sprintf("\n[%s/%s/%s](%s)\n",
+			r.captureMap["user"], r.captureMap["repo"], r.captureMap["path"], r.word)
+		ext := path.Ext(r.captureMap["path"])
+		// remove the preceding dot
+		if len(ext) > 1 {
+			ext = ext[1:]
+		}
+		final += "```" + ext + "\n"
+		final += lines
+		final += "```\n"
+
+		// replace word in msg starting from r.index only once
+		msg = msg[:r.index] + strings.Replace(msg[r.index:], r.word, final, 1)
+	}
+	return msg
+}

--- a/server/permalinks.go
+++ b/server/permalinks.go
@@ -68,7 +68,7 @@ func (p *Plugin) getReplacements(msg string) []replacement {
 
 // makeReplacements perform the given replacements on the msg and returns
 // the new msg.
-func (p *Plugin) makeReplacements(msg string, replacements []replacement) string {
+func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClient *github.Client) string {
 	// iterating the slice in reverse to preserve the replacement indices.
 	for i := len(replacements) - 1; i >= 0; i-- {
 		r := replacements[i]
@@ -84,7 +84,7 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement) string
 		}
 		// TODO: make all of these requests concurrently.
 		reqctx, cancel := context.WithTimeout(context.Background(), permalinkReqTimeout)
-		fileContent, _, _, err := p.githubClient.Repositories.GetContents(reqctx,
+		fileContent, _, _, err := ghClient.Repositories.GetContents(reqctx,
 			r.captureMap["user"], r.captureMap["repo"], r.captureMap["path"], &opts)
 		if err != nil {
 			p.API.LogError("error while fetching file contents", "error", err.Error(), "path", r.captureMap["path"])

--- a/server/permalinks_test.go
+++ b/server/permalinks_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetReplacements(t *testing.T) {
+	p := New()
+
+	tcs := []struct {
+		name            string
+		input           string
+		numReplacements int
+		replacements    []replacement
+	}{
+		{
+			name:            "basic one link",
+			input:           "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
+			numReplacements: 1,
+			replacements: []replacement{
+				{
+					index: 6,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					captureMap: map[string]string{
+						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
+						"haswww": "",
+						"line":   "L15-L22",
+						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				},
+			},
+		}, {
+			name:            "duplicate expansions",
+			input:           "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
+			numReplacements: 2,
+			replacements: []replacement{
+				{
+					index: 6,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					captureMap: map[string]string{
+						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
+						"haswww": "",
+						"line":   "L15-L22",
+						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				}, {
+					index: 142,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					captureMap: map[string]string{
+						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
+						"haswww": "",
+						"line":   "L15-L22",
+						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				},
+			},
+		}, {
+			name:            "inside link",
+			input:           "should not expand [link](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22) here",
+			numReplacements: 0,
+			replacements:    []replacement{},
+		}, {
+			name:            "one link, one expansion",
+			input:           "first should not expand [link](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22) this should https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
+			numReplacements: 1,
+			replacements: []replacement{
+				{
+					index: 168,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					captureMap: map[string]string{
+						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
+						"haswww": "",
+						"line":   "L15-L22",
+						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				},
+			},
+		}, {
+			name:            "one expansion, one link",
+			input:           "first should expand https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum , this should not [link](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)",
+			numReplacements: 1,
+			replacements: []replacement{
+				{
+					index: 20,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					captureMap: map[string]string{
+						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
+						"haswww": "",
+						"line":   "L15-L22",
+						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				},
+			},
+		}, {
+			name:            "2 links",
+			input:           "both should not expand- [link](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22) and [link](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)",
+			numReplacements: 0,
+			replacements:    []replacement{},
+		}, {
+			name:            "multiple expansions",
+			input:           "multiple - https://github.com/golang/go/blob/27fc32ff01cc699e160890546816bd99d6c57823/src/debug/macho/macho.go#L13-L16 second https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+			numReplacements: 2,
+			replacements: []replacement{
+				{
+					index: 11,
+					word:  "https://github.com/golang/go/blob/27fc32ff01cc699e160890546816bd99d6c57823/src/debug/macho/macho.go#L13-L16",
+					captureMap: map[string]string{
+						"commit": "27fc32ff01cc699e160890546816bd99d6c57823",
+						"haswww": "",
+						"line":   "L13-L16",
+						"path":   "src/debug/macho/macho.go",
+						"user":   "golang",
+						"repo":   "go",
+					},
+				}, {
+					index: 126,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					captureMap: map[string]string{
+						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
+						"haswww": "",
+						"line":   "L15-L22",
+						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			replacements := p.getReplacements(tc.input)
+			require.Equalf(t, tc.numReplacements, len(replacements), "unexpected no. of replacements for %s", tc.input)
+			for i, r := range replacements {
+				assert.Equalf(t, tc.replacements[i].index, r.index, "unexpected replacement index")
+				assert.Equalf(t, tc.replacements[i].word, r.word, "unexpected replacement word")
+				assert.Equalf(t, tc.replacements[i].captureMap["commit"], r.captureMap["commit"], "unexpected github commit")
+				assert.Equalf(t, tc.replacements[i].captureMap["haswww"], r.captureMap["haswww"], "unexpected github www domain")
+				assert.Equalf(t, tc.replacements[i].captureMap["line"], r.captureMap["line"], "unexpected line number")
+				assert.Equalf(t, tc.replacements[i].captureMap["path"], r.captureMap["path"], "unexpected file path")
+				assert.Equalf(t, tc.replacements[i].captureMap["user"], r.captureMap["user"], "unexpected github user")
+				assert.Equalf(t, tc.replacements[i].captureMap["repo"], r.captureMap["repo"], "unexpected github repo")
+			}
+		})
+	}
+}

--- a/server/permalinks_test.go
+++ b/server/permalinks_test.go
@@ -1,10 +1,18 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/google/go-github/v25/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
 )
 
 func TestGetReplacements(t *testing.T) {
@@ -24,13 +32,20 @@ func TestGetReplacements(t *testing.T) {
 				{
 					index: 6,
 					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
-					captureMap: map[string]string{
-						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
-						"haswww": "",
-						"line":   "L15-L22",
-						"path":   "app/authentication.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						haswww: "",
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				},
 			},
@@ -42,24 +57,38 @@ func TestGetReplacements(t *testing.T) {
 				{
 					index: 6,
 					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
-					captureMap: map[string]string{
-						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
-						"haswww": "",
-						"line":   "L15-L22",
-						"path":   "app/authentication.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				}, {
 					index: 142,
 					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
-					captureMap: map[string]string{
-						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
-						"haswww": "",
-						"line":   "L15-L22",
-						"path":   "app/authentication.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				},
 			},
@@ -76,13 +105,20 @@ func TestGetReplacements(t *testing.T) {
 				{
 					index: 168,
 					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
-					captureMap: map[string]string{
-						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
-						"haswww": "",
-						"line":   "L15-L22",
-						"path":   "app/authentication.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				},
 			},
@@ -94,13 +130,20 @@ func TestGetReplacements(t *testing.T) {
 				{
 					index: 20,
 					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
-					captureMap: map[string]string{
-						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
-						"haswww": "",
-						"line":   "L15-L22",
-						"path":   "app/authentication.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				},
 			},
@@ -117,24 +160,38 @@ func TestGetReplacements(t *testing.T) {
 				{
 					index: 11,
 					word:  "https://github.com/golang/go/blob/27fc32ff01cc699e160890546816bd99d6c57823/src/debug/macho/macho.go#L13-L16",
-					captureMap: map[string]string{
-						"commit": "27fc32ff01cc699e160890546816bd99d6c57823",
-						"haswww": "",
-						"line":   "L13-L16",
-						"path":   "src/debug/macho/macho.go",
-						"user":   "golang",
-						"repo":   "go",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "27fc32ff01cc699e160890546816bd99d6c57823",
+						haswww: "",
+						line:   "L13-L16",
+						path:   "src/debug/macho/macho.go",
+						user:   "golang",
+						repo:   "go",
 					},
 				}, {
 					index: 126,
 					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
-					captureMap: map[string]string{
-						"commit": "cbb25838a61872b624ac512556d7bc932486a64c",
-						"haswww": "",
-						"line":   "L15-L22",
-						"path":   "app/authentication.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				},
 			},
@@ -146,13 +203,20 @@ func TestGetReplacements(t *testing.T) {
 				{
 					index: 29,
 					word:  "https://github.com/mattermost/mattermost-server/blob/4225977966cf0855c8a5e55f8a0fef702b19dc18/api4/bot.go#L16",
-					captureMap: map[string]string{
-						"commit": "4225977966cf0855c8a5e55f8a0fef702b19dc18",
-						"haswww": "",
-						"line":   "L16",
-						"path":   "api4/bot.go",
-						"user":   "mattermost",
-						"repo":   "mattermost-server",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "4225977966cf0855c8a5e55f8a0fef702b19dc18",
+						haswww: "",
+						line:   "L16",
+						path:   "api4/bot.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
 					},
 				},
 			},
@@ -162,17 +226,247 @@ func TestGetReplacements(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			replacements := p.getReplacements(tc.input)
-			require.Equalf(t, tc.numReplacements, len(replacements), "unexpected no. of replacements for %s", tc.input)
+			require.Equalf(t, tc.numReplacements, len(replacements), "unexpected number of replacements for %s", tc.input)
 			for i, r := range replacements {
 				assert.Equalf(t, tc.replacements[i].index, r.index, "unexpected replacement index")
 				assert.Equalf(t, tc.replacements[i].word, r.word, "unexpected replacement word")
-				assert.Equalf(t, tc.replacements[i].captureMap["commit"], r.captureMap["commit"], "unexpected github commit")
-				assert.Equalf(t, tc.replacements[i].captureMap["haswww"], r.captureMap["haswww"], "unexpected github www domain")
-				assert.Equalf(t, tc.replacements[i].captureMap["line"], r.captureMap["line"], "unexpected line number")
-				assert.Equalf(t, tc.replacements[i].captureMap["path"], r.captureMap["path"], "unexpected file path")
-				assert.Equalf(t, tc.replacements[i].captureMap["user"], r.captureMap["user"], "unexpected github user")
-				assert.Equalf(t, tc.replacements[i].captureMap["repo"], r.captureMap["repo"], "unexpected github repo")
+				assert.Equalf(t, tc.replacements[i].permalinkInfo.commit, r.permalinkInfo.commit, "unexpected github commit")
+				assert.Equalf(t, tc.replacements[i].permalinkInfo.haswww, r.permalinkInfo.haswww, "unexpected github www domain")
+				assert.Equalf(t, tc.replacements[i].permalinkInfo.line, r.permalinkInfo.line, "unexpected line number")
+				assert.Equalf(t, tc.replacements[i].permalinkInfo.path, r.permalinkInfo.path, "unexpected file path")
+				assert.Equalf(t, tc.replacements[i].permalinkInfo.user, r.permalinkInfo.user, "unexpected github user")
+				assert.Equalf(t, tc.replacements[i].permalinkInfo.repo, r.permalinkInfo.repo, "unexpected github repo")
 			}
 		})
 	}
+}
+
+func TestMakeReplacements(t *testing.T) {
+	p := NewPlugin()
+	mockPluginAPI := &plugintest.API{}
+	mockPluginAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockPluginAPI.On("LogWarn", mock.Anything, mock.Anything)
+	p.SetAPI(mockPluginAPI)
+
+	tcs := []struct {
+		name         string
+		input        string
+		output       string
+		replacements []replacement
+	}{
+		{
+			name:   "basic one link",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
+			replacements: []replacement{
+				{
+					index: 6,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						haswww: "",
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
+					},
+				},
+			},
+		},
+		{
+			name:   "duplicate expansions",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
+			replacements: []replacement{
+				{
+					index: 6,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
+					},
+				}, {
+					index: 142,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						haswww: "",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
+					},
+				},
+			},
+		},
+		{
+			name:   "bad commit hash",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/badhash/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start https://github.com/mattermost/mattermost-server/blob/badhash/app/authentication.go#L15-L22 lorem ipsum",
+			replacements: []replacement{
+				{
+					index: 6,
+					word:  "https://github.com/mattermost/mattermost-server/blob/badhash/app/authentication.go#L15-L22",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						haswww: "",
+						commit: "badhash",
+						line:   "L15-L22",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
+					},
+				},
+			},
+		},
+		{
+			name:   "bad line range",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L22-L15 lorem ipsum",
+			output: "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L22-L15 lorem ipsum",
+			replacements: []replacement{
+				{
+					index: 6,
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L22-L15",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						haswww: "",
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						line:   "L22-L15",
+						path:   "app/authentication.go",
+						user:   "mattermost",
+						repo:   "mattermost-server",
+					},
+				},
+			},
+		},
+		{
+			name:   "bad file content",
+			input:  "start https://github.com/badorg/badrepo/path/file.go#L1-L2 lorem ipsum",
+			output: "start https://github.com/badorg/badrepo/path/file.go#L1-L2 lorem ipsum",
+			replacements: []replacement{
+				{
+					index: 5,
+					word:  "https://github.com/badorg/badrepo/path/file.go#L1-L2",
+					permalinkInfo: struct {
+						haswww string
+						commit string
+						user   string
+						repo   string
+						path   string
+						line   string
+					}{
+						haswww: "",
+						commit: "cbb25838a61872b624ac512556d7bc932486a64c",
+						line:   "L1-L2",
+						path:   "path/file.go",
+						user:   "badorg",
+						repo:   "badrepo",
+					},
+				},
+			},
+		},
+	}
+	client, close := getClient()
+	defer close()
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := p.makeReplacements(tc.input, tc.replacements, client)
+			assert.Equalf(t, tc.output, msg, "mismatched output")
+		})
+	}
+
+	mockPluginAPI.AssertCalled(t, "LogError", "bad git commit hash in permalink", "error", "encoding/hex: invalid byte: U+0068 'h'", "hash", "badhash")
+	mockPluginAPI.AssertCalled(t, "LogError", "error while fetching file contents", "error", "unmarshalling failed for both file and directory content: unexpected end of JSON input and unexpected end of JSON input", "path", "path/file.go")
+}
+
+const (
+	baseURLPath = "/api-v3"
+)
+
+func getClient() (*github.Client, func()) {
+	apiHandler := http.NewServeMux()
+	apiHandler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api-v3/repos/mattermost/mattermost-server/contents/app/authentication.go":
+			fmt.Fprintln(w, `{
+  "name": "authentication.go",
+  "path": "app/authentication.go",
+  "sha": "c5c4ebf9077d04306ce8eca1e451421e4df7ca3c",
+  "size": 7950,
+  "url": "https://api.github.com/repos/mattermost/mattermost-server/contents/app/authentication.go?ref=cbb25838a61872b624ac512556d7bc932486a64c",
+  "html_url": "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go",
+  "git_url": "https://api.github.com/repos/mattermost/mattermost-server/git/blobs/c5c4ebf9077d04306ce8eca1e451421e4df7ca3c",
+  "download_url": "https://raw.githubusercontent.com/mattermost/mattermost-server/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go",
+  "type": "file",
+  "content": "Ly8gQ29weXJpZ2h0IChjKSAyMDE2LXByZXNlbnQgTWF0dGVybW9zdCwgSW5j\nLiBBbGwgUmlnaHRzIFJlc2VydmVkLgovLyBTZWUgTGljZW5zZS50eHQgZm9y\nIGxpY2Vuc2UgaW5mb3JtYXRpb24uCgpwYWNrYWdlIGFwcAoKaW1wb3J0ICgK\nCSJuZXQvaHR0cCIKCSJzdHJpbmdzIgoKCSJnaXRodWIuY29tL21hdHRlcm1v\nc3QvbWF0dGVybW9zdC1zZXJ2ZXIvbW9kZWwiCgkiZ2l0aHViLmNvbS9tYXR0\nZXJtb3N0L21hdHRlcm1vc3Qtc2VydmVyL3NlcnZpY2VzL21mYSIKCSJnaXRo\ndWIuY29tL21hdHRlcm1vc3QvbWF0dGVybW9zdC1zZXJ2ZXIvdXRpbHMiCikK\nCnR5cGUgVG9rZW5Mb2NhdGlvbiBpbnQKCmNvbnN0ICgKCVRva2VuTG9jYXRp\nb25Ob3RGb3VuZCBUb2tlbkxvY2F0aW9uID0gaW90YQoJVG9rZW5Mb2NhdGlv\nbkhlYWRlcgoJVG9rZW5Mb2NhdGlvbkNvb2tpZQoJVG9rZW5Mb2NhdGlvblF1\nZXJ5U3RyaW5nCikKCmZ1bmMgKHRsIFRva2VuTG9jYXRpb24pIFN0cmluZygp\nIHN0cmluZyB7Cglzd2l0Y2ggdGwgewoJY2FzZSBUb2tlbkxvY2F0aW9uTm90\nRm91bmQ6CgkJcmV0dXJuICJOb3QgRm91bmQiCgljYXNlIFRva2VuTG9jYXRp\nb25IZWFkZXI6CgkJcmV0dXJuICJIZWFkZXIiCgljYXNlIFRva2VuTG9jYXRp\nb25Db29raWU6CgkJcmV0dXJuICJDb29raWUiCgljYXNlIFRva2VuTG9jYXRp\nb25RdWVyeVN0cmluZzoKCQlyZXR1cm4gIlF1ZXJ5U3RyaW5nIgoJZGVmYXVs\ndDoKCQlyZXR1cm4gIlVua25vd24iCgl9Cn0KCmZ1bmMgKGEgKkFwcCkgSXNQ\nYXNzd29yZFZhbGlkKHBhc3N3b3JkIHN0cmluZykgKm1vZGVsLkFwcEVycm9y\nIHsKCglpZiAqYS5Db25maWcoKS5TZXJ2aWNlU2V0dGluZ3MuRW5hYmxlRGV2\nZWxvcGVyIHsKCQlyZXR1cm4gbmlsCgl9CgoJcmV0dXJuIHV0aWxzLklzUGFz\nc3dvcmRWYWxpZFdpdGhTZXR0aW5ncyhwYXNzd29yZCwgJmEuQ29uZmlnKCku\nUGFzc3dvcmRTZXR0aW5ncykKfQoKZnVuYyAoYSAqQXBwKSBDaGVja1Bhc3N3\nb3JkQW5kQWxsQ3JpdGVyaWEodXNlciAqbW9kZWwuVXNlciwgcGFzc3dvcmQg\nc3RyaW5nLCBtZmFUb2tlbiBzdHJpbmcpICptb2RlbC5BcHBFcnJvciB7Cglp\nZiBlcnIgOj0gYS5DaGVja1VzZXJQcmVmbGlnaHRBdXRoZW50aWNhdGlvbkNy\naXRlcmlhKHVzZXIsIG1mYVRva2VuKTsgZXJyICE9IG5pbCB7CgkJcmV0dXJu\nIGVycgoJfQoKCWlmIGVyciA6PSBhLmNoZWNrVXNlclBhc3N3b3JkKHVzZXIs\nIHBhc3N3b3JkKTsgZXJyICE9IG5pbCB7CgkJaWYgcGFzc0VyciA6PSBhLlNy\ndi5TdG9yZS5Vc2VyKCkuVXBkYXRlRmFpbGVkUGFzc3dvcmRBdHRlbXB0cyh1\nc2VyLklkLCB1c2VyLkZhaWxlZEF0dGVtcHRzKzEpOyBwYXNzRXJyICE9IG5p\nbCB7CgkJCXJldHVybiBwYXNzRXJyCgkJfQoJCXJldHVybiBlcnIKCX0KCglp\nZiBlcnIgOj0gYS5DaGVja1VzZXJNZmEodXNlciwgbWZhVG9rZW4pOyBlcnIg\nIT0gbmlsIHsKCQkvLyBJZiB0aGUgbWZhVG9rZW4gaXMgbm90IHNldCwgd2Ug\nYXNzdW1lIHRoZSBjbGllbnQgdXNlZCB0aGlzIGFzIGEgcHJlLWZsaWdodCBy\nZXF1ZXN0IHRvIHF1ZXJ5IHRoZSBzZXJ2ZXIKCQkvLyBhYm91dCB0aGUgTUZB\nIHN0YXRlIG9mIHRoZSB1c2VyIGluIHF1ZXN0aW9uCgkJaWYgbWZhVG9rZW4g\nIT0gIiIgewoJCQlpZiBwYXNzRXJyIDo9IGEuU3J2LlN0b3JlLlVzZXIoKS5V\ncGRhdGVGYWlsZWRQYXNzd29yZEF0dGVtcHRzKHVzZXIuSWQsIHVzZXIuRmFp\nbGVkQXR0ZW1wdHMrMSk7IHBhc3NFcnIgIT0gbmlsIHsKCQkJCXJldHVybiBw\nYXNzRXJyCgkJCX0KCQl9CgkJcmV0dXJuIGVycgoJfQoKCWlmIHBhc3NFcnIg\nOj0gYS5TcnYuU3RvcmUuVXNlcigpLlVwZGF0ZUZhaWxlZFBhc3N3b3JkQXR0\nZW1wdHModXNlci5JZCwgMCk7IHBhc3NFcnIgIT0gbmlsIHsKCQlyZXR1cm4g\ncGFzc0VycgoJfQoKCWlmIGVyciA6PSBhLkNoZWNrVXNlclBvc3RmbGlnaHRB\ndXRoZW50aWNhdGlvbkNyaXRlcmlhKHVzZXIpOyBlcnIgIT0gbmlsIHsKCQly\nZXR1cm4gZXJyCgl9CgoJcmV0dXJuIG5pbAp9CgovLyBUaGlzIHRvIGJlIHVz\nZWQgZm9yIHBsYWNlcyB3ZSBjaGVjayB0aGUgdXNlcnMgcGFzc3dvcmQgd2hl\nbiB0aGV5IGFyZSBhbHJlYWR5IGxvZ2dlZCBpbgpmdW5jIChhICpBcHApIERv\ndWJsZUNoZWNrUGFzc3dvcmQodXNlciAqbW9kZWwuVXNlciwgcGFzc3dvcmQg\nc3RyaW5nKSAqbW9kZWwuQXBwRXJyb3IgewoJaWYgZXJyIDo9IGNoZWNrVXNl\nckxvZ2luQXR0ZW1wdHModXNlciwgKmEuQ29uZmlnKCkuU2VydmljZVNldHRp\nbmdzLk1heGltdW1Mb2dpbkF0dGVtcHRzKTsgZXJyICE9IG5pbCB7CgkJcmV0\ndXJuIGVycgoJfQoKCWlmIGVyciA6PSBhLmNoZWNrVXNlclBhc3N3b3JkKHVz\nZXIsIHBhc3N3b3JkKTsgZXJyICE9IG5pbCB7CgkJaWYgcGFzc0VyciA6PSBh\nLlNydi5TdG9yZS5Vc2VyKCkuVXBkYXRlRmFpbGVkUGFzc3dvcmRBdHRlbXB0\ncyh1c2VyLklkLCB1c2VyLkZhaWxlZEF0dGVtcHRzKzEpOyBwYXNzRXJyICE9\nIG5pbCB7CgkJCXJldHVybiBwYXNzRXJyCgkJfQoJCXJldHVybiBlcnIKCX0K\nCglpZiBwYXNzRXJyIDo9IGEuU3J2LlN0b3JlLlVzZXIoKS5VcGRhdGVGYWls\nZWRQYXNzd29yZEF0dGVtcHRzKHVzZXIuSWQsIDApOyBwYXNzRXJyICE9IG5p\nbCB7CgkJcmV0dXJuIHBhc3NFcnIKCX0KCglyZXR1cm4gbmlsCn0KCmZ1bmMg\n",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/mattermost/mattermost-server/contents/app/authentication.go?ref=cbb25838a61872b624ac512556d7bc932486a64c",
+    "git": "https://api.github.com/repos/mattermost/mattermost-server/git/blobs/c5c4ebf9077d04306ce8eca1e451421e4df7ca3c",
+    "html": "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go"
+  }
+}`)
+		case "/api-v3/repos/badorg/badrepo/path/file.go":
+			fmt.Fprintln(w, `{
+  "sha": "c5c4ebf9077d04306ce8eca1e451421e4df7ca3c",
+  "size": 7950,
+  "url": "https://api.github.com/repos/badorg/badrepo/path/file.g",
+  "html_url": "https://github.com/badorg/badrepo/path/file.g",
+  "git_url": "https://api.github.com/repos/badorg/badrepo/path/file.g",
+  "download_url": "https://raw.githubusercontent.com/badorg/badrepo/path/file.g",
+  "type": "file",
+  "content": "badinput",
+  "encoding": "base64"
+}`)
+		}
+	})
+
+	// server is a test HTTP server used to provide mock API responses.
+	server := httptest.NewServer(apiHandler)
+
+	// client is the GitHub client being tested and is
+	// configured to use test server.
+	client := github.NewClient(nil)
+	url, _ := url.Parse(server.URL + baseURLPath + "/")
+	client.BaseURL = url
+	client.UploadURL = url
+	return client, server.Close
 }

--- a/server/permalinks_test.go
+++ b/server/permalinks_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetReplacements(t *testing.T) {
-	p := New()
+	p := NewPlugin()
 
 	tcs := []struct {
 		name            string
@@ -133,6 +133,24 @@ func TestGetReplacements(t *testing.T) {
 						"haswww": "",
 						"line":   "L15-L22",
 						"path":   "app/authentication.go",
+						"user":   "mattermost",
+						"repo":   "mattermost-server",
+					},
+				},
+			},
+		}, {
+			name:            "single line",
+			input:           "this is a one line permalink https://github.com/mattermost/mattermost-server/blob/4225977966cf0855c8a5e55f8a0fef702b19dc18/api4/bot.go#L16",
+			numReplacements: 1,
+			replacements: []replacement{
+				{
+					index: 29,
+					word:  "https://github.com/mattermost/mattermost-server/blob/4225977966cf0855c8a5e55f8a0fef702b19dc18/api4/bot.go#L16",
+					captureMap: map[string]string{
+						"commit": "4225977966cf0855c8a5e55f8a0fef702b19dc18",
+						"haswww": "",
+						"line":   "L16",
+						"path":   "api4/bot.go",
 						"user":   "mattermost",
 						"repo":   "mattermost-server",
 					},

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -42,7 +42,7 @@ const (
 
 type Plugin struct {
 	plugin.MattermostPlugin
-	githubClient         *github.Client
+	// githubPermalinkRegex is used to parse github permalinks in post messages.
 	githubPermalinkRegex *regexp.Regexp
 
 	BotUserID string

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -132,10 +132,14 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		return nil, ""
 	}
 
+	if post.UserId == "" {
+		return nil, ""
+	}
+
 	msg := post.Message
 	info, err := p.getGitHubUserInfo(post.UserId)
 	if err != nil {
-		p.API.LogError("error in getting user info", "error", err)
+		p.API.LogError("error in getting user info", "error", err.Message)
 		return nil, ""
 	}
 	// TODO: make this part of the Plugin struct and reuse it.

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -138,11 +138,11 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		p.API.LogError("error in getting user info", "error", err)
 		return nil, ""
 	}
-	// TODO: store it during instance creation time and reuse it for all calls.
-	p.githubClient = p.githubConnect(*info.Token)
+	// TODO: make this part of the Plugin struct and reuse it.
+	ghClient := p.githubConnect(*info.Token)
 
 	replacements := p.getReplacements(msg)
-	post.Message = p.makeReplacements(msg, replacements)
+	post.Message = p.makeReplacements(msg, replacements, ghClient)
 	return post, ""
 }
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -177,26 +177,19 @@ func fullNameFromOwnerAndRepo(owner, repo string) string {
 	return fmt.Sprintf("%s/%s", owner, repo)
 }
 
-// filter lines in a string from start to end
+// filterLines filter lines in a string from start to end.
 func filterLines(s string, start, end int) (string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(s))
 	var buf strings.Builder
-	i := 1
-	for scanner.Scan() {
+	for i := 1; scanner.Scan() && i <= end; i++ {
 		if i < start {
-			i++
 			continue
-		}
-		if i > end {
-			break
 		}
 		buf.Write(scanner.Bytes())
 		buf.WriteByte(byte('\n'))
-		i++
 	}
-	err := scanner.Err()
 
-	return buf.String(), err
+	return buf.String(), scanner.Err()
 }
 
 // getLineNumbers return the start and end lines from an anchor tag
@@ -284,10 +277,9 @@ func isInsideLink(msg string, index int) bool {
 }
 
 // getCodeMarkdown returns the constructed markdown for a permalink.
-func getCodeMarkdown(captureMap map[string]string, word, lines string, isTruncated bool) string {
-	final := fmt.Sprintf("\n[%s/%s/%s](%s)\n",
-		captureMap["user"], captureMap["repo"], captureMap["path"], word)
-	ext := path.Ext(captureMap["path"])
+func getCodeMarkdown(user, repo, repoPath, word, lines string, isTruncated bool) string {
+	final := fmt.Sprintf("\n[%s/%s/%s](%s)\n", user, repo, repoPath, word)
+	ext := path.Ext(repoPath)
 	// remove the preceding dot
 	if len(ext) > 1 {
 		ext = strings.TrimPrefix(ext, ".")

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
@@ -9,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -172,4 +174,107 @@ func fixGithubNotificationSubjectURL(url string) string {
 
 func fullNameFromOwnerAndRepo(owner, repo string) string {
 	return fmt.Sprintf("%s/%s", owner, repo)
+}
+
+// filter lines in a string from start to end
+func filterLines(s string, start, end int) string {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	var buf strings.Builder
+	i := 1
+	for scanner.Scan() {
+		if i < start {
+			i++
+			continue
+		}
+		if i > end {
+			break
+		}
+		buf.Write(scanner.Bytes())
+		buf.WriteByte(byte('\n'))
+		i++
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println(err)
+	}
+
+	return buf.String()
+}
+
+// getLineNumbers return the start and end lines from an anchor tag
+// of a github permalink.
+func getLineNumbers(s string) (start, end int) {
+	// split till -
+	parts := strings.Split(s, "-")
+
+	if len(parts) > 2 {
+		return -1, -1
+	}
+
+	switch len(parts) {
+	case 1: // just a single line
+		l := getLine(parts[0])
+		if l == -1 {
+			return -1, -1
+		}
+		if l < 3 {
+			return 0, l + 3
+		}
+		return l - 3, l + 3
+	case 2: // a line rage
+		start := getLine(parts[0])
+		end := getLine(parts[1])
+		return start, end
+	}
+	return -1, -1
+}
+
+// getLine returns the line number in int from a string
+// of form L<num>.
+func getLine(s string) int {
+	// check starting L and minimum length
+	if !strings.HasPrefix(s, "L") || len(s) < 2 {
+		return -1
+	}
+
+	line, err := strconv.Atoi(s[1:])
+	if err != nil {
+		return -1
+	}
+	return line
+}
+
+// isInsideLink reports whether the given index in a string is preceeded
+// by zero or more space, then (, then ].
+//
+// It is a poor man's version of checking markdown hyperlinks without
+// using a full-blown markdown parser. The idea is to quickly confirm
+// whether a permalink is inside a markdown link or not. Something like
+// "text ]( permalink" is rare enough. Even then, it is okay if
+// there are false positives, but there cannot be any false negatives.
+//
+// Note: it is fine to go one byte at a time instead of one rune because
+// we are anyways looking for ASCII chars.
+func isInsideLink(msg string, index int) bool {
+	stage := 0 // 0 is looking for space or ( and 1 for ]
+
+	for i := index; i > 0; i-- {
+		char := msg[i-1]
+		switch stage {
+		case 0:
+			if char == ' ' {
+				continue
+			}
+			if char == '(' {
+				stage++
+				continue
+			}
+			return false
+		case 1:
+			if char == ']' {
+				return true
+			}
+			return false
+		}
+	}
+	return false
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -177,7 +177,7 @@ func fullNameFromOwnerAndRepo(owner, repo string) string {
 	return fmt.Sprintf("%s/%s", owner, repo)
 }
 
-// filterLines filter lines in a string from start to end.
+// filterLines filters lines in a string from start to end.
 func filterLines(s string, start, end int) (string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(s))
 	var buf strings.Builder

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -78,3 +78,83 @@ func TestParseOwnerAndRepo(t *testing.T) {
 		assert.Equal(t, repo, tc.ExpectedRepo)
 	}
 }
+
+func TestGetLineNumbers(t *testing.T) {
+	tcs := []struct {
+		input      string
+		start, end int
+	}{
+		{
+			input: "L19",
+			start: 16,
+			end:   22,
+		}, {
+			input: "L19-L23",
+			start: 19,
+			end:   23,
+		}, {
+			input: "L",
+			start: -1,
+			end:   -1,
+		}, {
+			input: "bad",
+			start: -1,
+			end:   -1,
+		}, {
+			input: "L99-",
+			start: 99,
+			end:   -1,
+		}, {
+			input: "L2",
+			start: 0,
+			end:   5,
+		},
+	}
+	for _, tc := range tcs {
+		start, end := getLineNumbers(tc.input)
+		assert.Equalf(t, tc.start, start, "unexepected start index for getLineNumbers(%q)", tc.input)
+		assert.Equalf(t, tc.end, end, "unexepected end index for getLineNumbers(%q)", tc.input)
+	}
+}
+
+func TestInsideLink(t *testing.T) {
+	tcs := []struct {
+		input    string
+		index    int
+		expected bool
+	}{
+		{
+			input:    "[text](link)",
+			index:    7,
+			expected: true,
+		}, {
+			input:    "[text]( link space)",
+			index:    8,
+			expected: true,
+		}, {
+			input:    "text](link",
+			index:    6,
+			expected: true,
+		}, {
+			input:    "text] (link)",
+			index:    7,
+			expected: false,
+		}, {
+			input:    "text](link)",
+			index:    6,
+			expected: true,
+		}, {
+			input:    "link",
+			index:    0,
+			expected: false,
+		}, {
+			input:    " (link)",
+			index:    2,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		assert.Equalf(t, tc.expected, isInsideLink(tc.input, tc.index), "unexepected result for isInsideLink(%q, %d)", tc.input, tc.index)
+	}
+}

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -93,6 +93,10 @@ func TestGetLineNumbers(t *testing.T) {
 			start: 19,
 			end:   23,
 		}, {
+			input: "L23-L19",
+			start: -1,
+			end:   -1,
+		}, {
 			input: "L",
 			start: -1,
 			end:   -1,
@@ -112,8 +116,8 @@ func TestGetLineNumbers(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		start, end := getLineNumbers(tc.input)
-		assert.Equalf(t, tc.start, start, "unexepected start index for getLineNumbers(%q)", tc.input)
-		assert.Equalf(t, tc.end, end, "unexepected end index for getLineNumbers(%q)", tc.input)
+		assert.Equalf(t, tc.start, start, "unexpected start index for getLineNumbers(%q)", tc.input)
+		assert.Equalf(t, tc.end, end, "unexpected end index for getLineNumbers(%q)", tc.input)
 	}
 }
 
@@ -155,6 +159,6 @@ func TestInsideLink(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		assert.Equalf(t, tc.expected, isInsideLink(tc.input, tc.index), "unexepected result for isInsideLink(%q, %d)", tc.input, tc.index)
+		assert.Equalf(t, tc.expected, isInsideLink(tc.input, tc.index), "unexpected result for isInsideLink(%q, %d)", tc.input, tc.index)
 	}
 }


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

For every message we now hook into the MessageWillBePosted event, and check
if it contains a permalink to a Github file.

If yes, we parse out the link, and make an API call to the Github contents API.
Get the file contents and filter out the required lines given in the permalink anchor.

Then we construct a code block in markdown and replace the original string.

Added a config key to gate this feature.

Screenshots:

With config disabled:
![before-mm](https://user-images.githubusercontent.com/1774000/66314942-790c5a00-e932-11e9-88bf-9acd29f88732.png)

After enabling it:
![after-mm](https://user-images.githubusercontent.com/1774000/66314961-7e69a480-e932-11e9-9b3b-8f6292790c79.png)
The newly formed hyperlink is a link to the original permalink

Config setting:
![codepreview](https://user-images.githubusercontent.com/1774000/66314978-84f81c00-e932-11e9-823e-46b751c4307e.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[MM-18880](https://mattermost.atlassian.net/browse/MM-18880)

Fixes #128 