### PR TITLE
[MM-19443] Link to the comment that cause the notification

### DIFF
--- a/server/template.go
+++ b/server/template.go
@@ -63,6 +63,16 @@ func init() {
 		`{{template "eventRepoPullRequest" .}} - {{.GetPullRequest.GetTitle}}`,
 	))
 
+	// The reviewRepoPullRequest links to the corresponding pull request, anchored at the repo.
+	template.Must(masterTemplate.New("reviewRepoPullRequest").Parse(
+		`[{{.GetRepo.GetFullName}}#{{.GetPullRequest.GetNumber}}]({{.GetReview.GetHTMLURL}})`,
+	))
+
+	// this reviewRepoPullRequestWithTitle just adds title
+	template.Must(masterTemplate.New("reviewRepoPullRequestWithTitle").Parse(
+		`{{template "reviewRepoPullRequest" .}} - {{.GetPullRequest.GetTitle}}`,
+	))
+
 	// The pullRequest links to the corresponding pull request, skipping the repo title.
 	template.Must(masterTemplate.New("pullRequest").Parse(
 		`[#{{.GetNumber}} {{.GetTitle}}]({{.GetHTMLURL}})`,
@@ -81,6 +91,19 @@ func init() {
 
 	template.Must(masterTemplate.New("eventRepoIssueWithTitle").Parse(
 		`{{template "eventRepoIssue" .}} - {{.GetIssue.GetTitle}}`,
+	))
+
+	// The eventRepoIssueFullLink links to the corresponding comment in the issue. Note that, for some events, the
+	// issue *is* a pull request, and so we still use .GetIssue and this template accordingly.
+	// and .GetComment return full link to the comment as long as comment object is present in the payload
+	template.Must(masterTemplate.New("eventRepoIssueFullLink").Parse(
+		`[{{.GetRepo.GetFullName}}#{{.GetIssue.GetNumber}}]({{.GetComment.GetHTMLURL}})`,
+	))
+
+	// eventRepoIssueFullLinkWithTitle template is sibling of eventRepoIssueWithTitle
+	// this one refers to the comment instead of the issue itself
+	template.Must(masterTemplate.New("eventRepoIssueFullLinkWithTitle").Parse(
+		`{{template "eventRepoIssueFullLink" .}} - {{.GetIssue.GetTitle}}`,
 	))
 
 	template.Must(masterTemplate.New("newPR").Funcs(funcMap).Parse(`
@@ -166,12 +189,12 @@ func init() {
 `))
 
 	template.Must(masterTemplate.New("commentAuthorPullRequestNotification").Funcs(funcMap).Parse(`
-{{template "user" .GetSender}} commented on your pull request {{template "eventRepoIssueWithTitle" .}}:
+{{template "user" .GetSender}} commented on your pull request {{template "eventRepoIssueFullLinkWithTitle" .}}:
 >{{.GetComment.GetBody | trimBody}}
 `))
 
 	template.Must(masterTemplate.New("commentAuthorIssueNotification").Funcs(funcMap).Parse(`
-{{template "user" .GetSender}} commented on your issue {{template "eventRepoIssueWithTitle" .}}
+{{template "user" .GetSender}} commented on your issue {{template "eventRepoIssueFullLinkWithTitle" .}}
 `))
 
 	template.Must(masterTemplate.New("pullRequestNotification").Funcs(funcMap).Parse(`
@@ -199,7 +222,7 @@ func init() {
 {{- if eq .GetReview.GetState "approved" }} approved your pull request
 {{- else if eq .GetReview.GetState "changes_requested" }} requested changes on your pull request
 {{- else if eq .GetReview.GetState "commented" }} commented on your pull request
-{{- end }} {{template "eventRepoPullRequestWithTitle" .}}
+{{- end }} {{template "reviewRepoPullRequestWithTitle" .}}
 `))
 }
 

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -539,7 +539,7 @@ func TestCommentMentionNotificationTemplate(t *testing.T) {
 
 func TestCommentAuthorPullRequestNotificationTemplate(t *testing.T) {
 	expected := `
-[panda](https://github.com/panda) commented on your pull request [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1) - Implement git-get-head:
+[panda](https://github.com/panda) commented on your pull request [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
 >@cpanato, anytime?
 `
 
@@ -558,7 +558,7 @@ func TestCommentAuthorPullRequestNotificationTemplate(t *testing.T) {
 
 func TestCommentAuthorIssueNotificationTemplate(t *testing.T) {
 	expected := `
-[panda](https://github.com/panda) commented on your issue [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1) - Implement git-get-head
+[panda](https://github.com/panda) commented on your issue [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head
 `
 
 	actual, err := renderTemplate("commentAuthorIssueNotification", &github.IssueCommentEvent{
@@ -706,7 +706,7 @@ func TestIssueNotification(t *testing.T) {
 func TestPullRequestReviewNotification(t *testing.T) {
 	t.Run("approved", func(t *testing.T) {
 		expected := `
-[panda](https://github.com/panda) approved your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42) - Leverage git-get-head
+[panda](https://github.com/panda) approved your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456) - Leverage git-get-head
 `
 
 		actual, err := renderTemplate("pullRequestReviewNotification", &github.PullRequestReviewEvent{
@@ -714,6 +714,7 @@ func TestPullRequestReviewNotification(t *testing.T) {
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
+				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
 				State: sToP("approved"),
 				Body:  sToP("Excited to see git-get-head land!"),
 			},
@@ -724,7 +725,7 @@ func TestPullRequestReviewNotification(t *testing.T) {
 
 	t.Run("changes_requested", func(t *testing.T) {
 		expected := `
-[panda](https://github.com/panda) requested changes on your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42) - Leverage git-get-head
+[panda](https://github.com/panda) requested changes on your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456) - Leverage git-get-head
 `
 
 		actual, err := renderTemplate("pullRequestReviewNotification", &github.PullRequestReviewEvent{
@@ -732,6 +733,7 @@ func TestPullRequestReviewNotification(t *testing.T) {
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
+				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
 				State: sToP("changes_requested"),
 				Body:  sToP("Excited to see git-get-head land!"),
 			},
@@ -742,7 +744,7 @@ func TestPullRequestReviewNotification(t *testing.T) {
 
 	t.Run("commented", func(t *testing.T) {
 		expected := `
-[panda](https://github.com/panda) commented on your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42) - Leverage git-get-head
+[panda](https://github.com/panda) commented on your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456) - Leverage git-get-head
 `
 
 		actual, err := renderTemplate("pullRequestReviewNotification", &github.PullRequestReviewEvent{
@@ -750,6 +752,7 @@ func TestPullRequestReviewNotification(t *testing.T) {
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
+				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
 				State: sToP("commented"),
 				Body:  sToP("Excited to see git-get-head land!"),
 			},


### PR DESCRIPTION
Some few changes on templates `pullRequestReviewNotification`, `commentAuthorPullRequestNotification` and `commentAuthorIssueNotification` added full comment link instead of using the main object that reference the comment

Had to created some new template to handle these changes correctly:
`reviewRepoPullRequest`: link of the review object
`commentRepoIssue`: link of the comment object

Changed unit tests according to these changes

Fixes #142 