### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,6 @@ require (
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/mattermost/mattermost-server v0.0.0-20191017141203-48c06e9bce3b
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/mattermost/mattermost-server v0.0.0-20191017141203-48c06e9bce3b
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-github",
     "support_url": "https://github.com/mattermost/mattermost-plugin-github/issues",
     "icon_path": "assets/icon.svg",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "min_server_version": "5.12.0",
     "server": {
       "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "github",
-	Version: "0.11.0",
+	Version: "0.12.0",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'github';
-export const version = '0.11.0';
+export const version = '0.12.0';


### PR DESCRIPTION
Bumping version to v0.12.0 to cut a new release, with the primary purpose of including the recent `plugin.json` metadata changes for programmatic consumption by the marketplace.