### PR TITLE
Exclude organization members feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Once connected, you'll have access to the following features:
           ```
           /github subscribe mattermost/mattermost-server issues,pulls,issue_comments,label:"Help Wanted"
           ```
-
+        - The following flags are supported:
+           - `--exclude-org-member`: events triggered by organization members will not be delivered. It will be locked to the organization
+            provided in the plugin configuration and it will only work for users whose membership is public. Note that organization members and collaborators
+            are not the same.
     * __Get to do items__ - Use `/github todo` to get an ephemeral message with items to do in GitHub, including a list of unread messages and pull requests awaiting your review
     * __Update settings__ - Use `/github settings` to update your settings for notifications and daily reminders
     * __And more!__ - Run `/github help` to see what else the slash command can do

--- a/server/command.go
+++ b/server/command.go
@@ -102,7 +102,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	case "subscribe":
 		config := p.getConfiguration()
 		features := "pulls,issues,creates,deletes"
-		flags := []string{}
+		flags := SubscriptionFlags{}
 
 		txt := ""
 		if len(parameters) == 0 {
@@ -130,7 +130,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 
 			for _, element := range parameters[1:] {
 				if isFlag(element) {
-					flags = append(flags, parseFlag(element))
+					flags.AddFlag(parseFlag(element))
 				} else {
 					optionList = append(optionList, element)
 				}

--- a/server/command.go
+++ b/server/command.go
@@ -123,21 +123,21 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			p.postCommandResponse(args, txt)
 			return &model.CommandResponse{}, nil
 		} else if len(parameters) > 1 {
-			featureList := []string{}
+			optionList := []string{}
 
 			for _, element := range parameters[1:] {
 				if isFlag(element) {
 					flags = append(flags, parseFlag(element))
 				} else {
-					featureList = append(featureList, element)
+					optionList = append(optionList, element)
 				}
 			}
 
-			if len(featureList) > 1 {
-				p.postCommandResponse(args, "Just one {features} parameter is allowed")
+			if len(optionList) > 1 {
+				p.postCommandResponse(args, "Just one option is allowed")
 				return &model.CommandResponse{}, nil
-			} else if len(featureList) == 1 {
-				features = featureList[0]
+			} else if len(optionList) == 1 {
+				features = optionList[0]
 			}
 		}
 

--- a/server/command.go
+++ b/server/command.go
@@ -134,7 +134,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			}
 
 			if len(optionList) > 1 {
-				p.postCommandResponse(args, "Just one option is allowed")
+				p.postCommandResponse(args, "Just one list of features is allowed")
 				return &model.CommandResponse{}, nil
 			} else if len(optionList) == 1 {
 				features = optionList[0]

--- a/server/command.go
+++ b/server/command.go
@@ -16,7 +16,7 @@ const COMMAND_HELP = `* |/github connect| - Connect your Mattermost account to y
 * |/github disconnect| - Disconnect your Mattermost account from your GitHub account
 * |/github todo| - Get a list of unread messages and pull requests awaiting your review
 * |/github subscribe list| - Will list the current channel subscriptions
-* |/github subscribe owner[/repo] [features]| - Subscribe the current channel to receive notifications about opened pull requests and issues for an organization or repository
+* |/github subscribe owner[/repo] [features] [flags]| - Subscribe the current channel to receive notifications about opened pull requests and issues for an organization or repository
   * |features| is a comma-delimited list of one or more the following:
     * issues - includes new and closed issues
 	* pulls - includes new and closed pull requests
@@ -26,7 +26,10 @@ const COMMAND_HELP = `* |/github connect| - Connect your Mattermost account to y
     * issue_comments - includes new issue comments
     * pull_reviews - includes pull request reviews
 	* label:"<labelname>" - must include "pulls" or "issues" in feature list when using a label
-  * Defaults to "pulls,issues,creates,deletes"
+	Defaults to "pulls,issues,creates,deletes"
+  * |flags| currently supported:
+    * --exclude-org-member - events triggered by organization members will not be delivered (the Github organization config
+		should be set, otherwise this flag has not effect)
 * |/github unsubscribe owner/repo| - Unsubscribe the current channel from a repository
 * |/github me| - Display the connected GitHub account
 * |/github settings [setting] [value]| - Update your user settings

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -442,6 +442,20 @@ func (p *Plugin) checkOrg(org string) error {
 	return nil
 }
 
+func (p *Plugin) isUserOrganizationMember(githubClient *github.Client, user *github.User, organization string) bool {
+	if organization == "" {
+		return false
+	}
+
+	isMember, _, err := githubClient.Organizations.IsMember(context.Background(), organization, *user.Login)
+
+	if err != nil {
+		return false
+	}
+
+	return isMember
+}
+
 func (p *Plugin) sendRefreshEvent(userID string) {
 	p.API.PublishWebSocketEvent(
 		WS_EVENT_REFRESH,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -448,7 +448,6 @@ func (p *Plugin) isUserOrganizationMember(githubClient *github.Client, user *git
 	}
 
 	isMember, _, err := githubClient.Organizations.IsMember(context.Background(), organization, *user.Login)
-
 	if err != nil {
 		mlog.Warn(err.Error())
 		return false

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -450,6 +450,7 @@ func (p *Plugin) isUserOrganizationMember(githubClient *github.Client, user *git
 	isMember, _, err := githubClient.Organizations.IsMember(context.Background(), organization, *user.Login)
 
 	if err != nil {
+		mlog.Warn(err.Error())
 		return false
 	}
 

--- a/server/subscriptions.go
+++ b/server/subscriptions.go
@@ -13,11 +13,19 @@ import (
 )
 
 const (
-	SUBSCRIPTIONS_KEY = "subscriptions"
+	SUBSCRIPTIONS_KEY       = "subscriptions"
+	EXCLUDE_ORG_MEMBER_FLAG = "exclude-org-member"
 )
 
 type SubscriptionFlags struct {
 	ExcludeOrgMembers bool
+}
+
+func (s *SubscriptionFlags) AddFlag(flag string) {
+	switch flag {
+	case EXCLUDE_ORG_MEMBER_FLAG:
+		s.ExcludeOrgMembers = true
+	}
 }
 
 type Subscription struct {
@@ -77,7 +85,7 @@ func (s *Subscription) ExcludeOrgMembers() bool {
 	return s.Flags.ExcludeOrgMembers
 }
 
-func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, userId, owner, repo, channelID, features string, flags []string) error {
+func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, userId, owner, repo, channelID, features string, flags SubscriptionFlags) error {
 	if owner == "" {
 		return fmt.Errorf("Invalid repository")
 	}
@@ -117,9 +125,7 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		CreatorID:  userId,
 		Features:   features,
 		Repository: fullNameFromOwnerAndRepo(owner, repo),
-		Flags: SubscriptionFlags{
-			ExcludeOrgMembers: containsValue(flags, "exclude-org-member"),
-		},
+		Flags:      flags,
 	}
 
 	if err := p.AddSubscription(fullNameFromOwnerAndRepo(owner, repo), sub); err != nil {
@@ -129,7 +135,7 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 	return nil
 }
 
-func (p *Plugin) SubscribeOrg(ctx context.Context, githubClient *github.Client, userId, org, channelID, features string, flags []string) error {
+func (p *Plugin) SubscribeOrg(ctx context.Context, githubClient *github.Client, userId, org, channelID, features string, flags SubscriptionFlags) error {
 	if org == "" {
 		return fmt.Errorf("Invalid organization")
 	}

--- a/server/utils.go
+++ b/server/utils.go
@@ -173,3 +173,21 @@ func fixGithubNotificationSubjectURL(url string) string {
 func fullNameFromOwnerAndRepo(owner, repo string) string {
 	return fmt.Sprintf("%s/%s", owner, repo)
 }
+
+func isFlag(text string) bool {
+	return strings.HasPrefix(text, "--")
+}
+
+func parseFlag(flag string) string {
+	return strings.TrimPrefix(flag, "--")
+}
+
+func containsValue(arr []string, value string) bool {
+	for _, element := range arr {
+		if element == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -119,7 +119,7 @@ func TestContainsValue(t *testing.T) {
 	}{
 		{List: []string{"value1", "value2"}, Value: "value1", Expected: true},
 		{List: []string{}, Value: "value1", Expected: false},
-		{List: []string{"value1", "value2"}, Value: "value1", Expected: true},
+		{List: []string{"value1", "value2"}, Value: "value2", Expected: true},
 	}
 
 	for _, tc := range tcs {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -78,3 +78,51 @@ func TestParseOwnerAndRepo(t *testing.T) {
 		assert.Equal(t, repo, tc.ExpectedRepo)
 	}
 }
+
+func TestIsFlag(t *testing.T) {
+	tcs := []struct {
+		Text     string
+		Expected bool
+	}{
+		{Text: "--test-flag", Expected: true},
+		{Text: "--testFlag", Expected: true},
+		{Text: "test-no-flag", Expected: false},
+		{Text: "testNoFlag", Expected: false},
+		{Text: "test no flag", Expected: false},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.Expected, isFlag(tc.Text))
+	}
+}
+
+func TestParseFlag(t *testing.T) {
+	tcs := []struct {
+		Text     string
+		Expected string
+	}{
+		{Text: "--test-flag", Expected: "test-flag"},
+		{Text: "--testFlag", Expected: "testFlag"},
+		{Text: "testNoFlag", Expected: "testNoFlag"},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.Expected, parseFlag(tc.Text))
+	}
+}
+
+func TestContainsValue(t *testing.T) {
+	tcs := []struct {
+		List     []string
+		Value    string
+		Expected bool
+	}{
+		{List: []string{"value1", "value2"}, Value: "value1", Expected: true},
+		{List: []string{}, Value: "value1", Expected: false},
+		{List: []string{"value1", "value2"}, Value: "value1", Expected: true},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.Expected, containsValue(tc.List, tc.Value))
+	}
+}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -387,6 +387,10 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 			continue
 		}
 
+		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
 			mlog.Error(err.Error())
@@ -426,6 +430,10 @@ func (p *Plugin) postCreateEvent(event *github.CreateEvent) {
 			continue
 		}
 
+		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
 			mlog.Error(err.Error())
@@ -462,6 +470,10 @@ func (p *Plugin) postDeleteEvent(event *github.DeleteEvent) {
 
 	for _, sub := range subs {
 		if !sub.Deletes() {
+			continue
+		}
+
+		if p.excludeConfigOrgMember(event.GetSender(), sub) {
 			continue
 		}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -171,6 +171,7 @@ func (p *Plugin) excludeConfigOrgMember(user *github.User, subscription *Subscri
 	info, err := p.getGitHubUserInfo(subscription.CreatorID)
 
 	if err != nil {
+		mlog.Warn(err.Message)
 		return false
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -169,7 +169,6 @@ func (p *Plugin) excludeConfigOrgMember(user *github.User, subscription *Subscri
 	}
 
 	info, err := p.getGitHubUserInfo(subscription.CreatorID)
-
 	if err != nil {
 		mlog.Warn(err.Message)
 		return false


### PR DESCRIPTION
- Command: we iterate through every parameter, identifying if it's a "feature" or a "flag" (for this purpose, some helper functions have been included in "utils")

- Subscription: a new struct for flags has been created.

- Plugin: a new method isUserOrganizationMember has been added.

- Webhook: a new method excludeConfigOrgMember has been included. It's responsible for fetching configuration and creating the GitHub client.

I have created two different methods so isUserOrganizationMember could be reused without any links to the purpose of this task.

Thanks!

Fixes https://github.com/mattermost/mattermost-plugin-github/issues/125