### PR TITLE
Remove timestamps and duplicate url from templates

### DIFF
--- a/server/template.go
+++ b/server/template.go
@@ -109,7 +109,7 @@ func init() {
 	template.Must(masterTemplate.New("newPR").Funcs(funcMap).Parse(`
 #### {{.GetPullRequest.GetTitle}}
 ##### {{template "eventRepoPullRequest" .}}
-#new-pull-request by {{template "user" .GetSender}} on [{{.GetPullRequest.GetCreatedAt.String}}]({{.GetPullRequest.GetHTMLURL}})
+#new-pull-request by {{template "user" .GetSender}}
 
 {{.GetPullRequest.GetBody}}
 `))
@@ -124,13 +124,13 @@ func init() {
 	template.Must(masterTemplate.New("pullRequestLabelled").Funcs(funcMap).Parse(`
 #### {{.GetPullRequest.GetTitle}}
 ##### {{template "eventRepoPullRequest" .}}
-#pull-request-labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}} on [{{.GetPullRequest.GetUpdatedAt.String}}]({{.GetPullRequest.GetHTMLURL}})
+#pull-request-labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}}
 `))
 
 	template.Must(masterTemplate.New("newIssue").Funcs(funcMap).Parse(`
 #### {{.GetIssue.GetTitle}}
 ##### {{template "eventRepoIssue" .}}
-#new-issue by {{template "user" .GetSender}} on [{{.GetIssue.GetCreatedAt.String}}]({{.GetIssue.GetHTMLURL}})
+#new-issue by {{template "user" .GetSender}}
 
 {{.GetIssue.GetBody}}
 `))
@@ -142,7 +142,7 @@ func init() {
 	template.Must(masterTemplate.New("issueLabelled").Funcs(funcMap).Parse(`
 #### {{.GetIssue.GetTitle}}
 ##### {{template "eventRepoIssue" .}}
-#issue-labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}} on [{{.GetIssue.GetUpdatedAt.String}}]({{.GetIssue.GetHTMLURL}}).
+#issue-labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}}.
 `))
 
 	template.Must(masterTemplate.New("pushedCommits").Funcs(funcMap).Parse(`

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -94,7 +94,7 @@ func TestNewPRMessageTemplate(t *testing.T) {
 	expected := `
 #### Leverage git-get-head
 ##### [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42)
-#new-pull-request by [panda](https://github.com/panda) on [2019-04-01 02:03:04 +0000 UTC](https://github.com/mattermost/mattermost-plugin-github/pull/42)
+#new-pull-request by [panda](https://github.com/panda)
 
 git-get-head gets the non-sent upstream heads inside the stashed non-cleaned applied areas, and after pruning bases to many archives, you can initialize the origin of the bases.
 `
@@ -142,7 +142,7 @@ func TestPullRequestLabelledTemplate(t *testing.T) {
 	expected := `
 #### Leverage git-get-head
 ##### [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42)
-#pull-request-labeled ` + "`label-name`" + ` by [panda](https://github.com/panda) on [2019-05-01 02:03:04 +0000 UTC](https://github.com/mattermost/mattermost-plugin-github/pull/42)
+#pull-request-labeled ` + "`label-name`" + ` by [panda](https://github.com/panda)
 `
 
 	actual, err := renderTemplate("pullRequestLabelled", &github.PullRequestEvent{
@@ -161,7 +161,7 @@ func TestNewIssueTemplate(t *testing.T) {
 	expected := `
 #### Implement git-get-head
 ##### [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1)
-#new-issue by [panda](https://github.com/panda) on [2019-04-01 02:03:04 +0000 UTC](https://github.com/mattermost/mattermost-plugin-github/issues/1)
+#new-issue by [panda](https://github.com/panda)
 
 git-get-head sounds like a great feature we should support
 `
@@ -193,7 +193,7 @@ func TestIssueLabelledTemplate(t *testing.T) {
 	expected := `
 #### Implement git-get-head
 ##### [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1)
-#issue-labeled ` + "`label-name`" + ` by [panda](https://github.com/panda) on [2019-05-01 02:03:04 +0000 UTC](https://github.com/mattermost/mattermost-plugin-github/issues/1).
+#issue-labeled ` + "`label-name`" + ` by [panda](https://github.com/panda).
 `
 
 	actual, err := renderTemplate("issueLabelled", &github.IssuesEvent{
@@ -716,8 +716,8 @@ func TestPullRequestReviewNotification(t *testing.T) {
 			Sender:      &user,
 			Review: &github.PullRequestReview{
 				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
-				State: sToP("approved"),
-				Body:  sToP("Excited to see git-get-head land!"),
+				State:   sToP("approved"),
+				Body:    sToP("Excited to see git-get-head land!"),
 			},
 		})
 		require.NoError(t, err)
@@ -736,8 +736,8 @@ func TestPullRequestReviewNotification(t *testing.T) {
 			Sender:      &user,
 			Review: &github.PullRequestReview{
 				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
-				State: sToP("changes_requested"),
-				Body:  sToP("Excited to see git-get-head land!"),
+				State:   sToP("changes_requested"),
+				Body:    sToP("Excited to see git-get-head land!"),
 			},
 		})
 		require.NoError(t, err)
@@ -756,8 +756,8 @@ func TestPullRequestReviewNotification(t *testing.T) {
 			Sender:      &user,
 			Review: &github.PullRequestReview{
 				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
-				State: sToP("commented"),
-				Body:  sToP("Excited to see git-get-head land!"),
+				State:   sToP("commented"),
+				Body:    sToP("Excited to see git-get-head land!"),
 			},
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
### Summary
- Removes timestamps from posts since the mattermost app already shows a timestamp when message is posted.
- Since the time shown by the github plugin is always UTC it is confusing since it is in a different timezone
- The consensus from this issue here https://github.com/mattermost/mattermost-plugin-github/issues/109 seemed to be to remove the timestamp entirely 

Fixes https://github.com/mattermost/mattermost-plugin-github/issues/109

### Screenshots
Heres what it currently looks like 
![Screen Shot 2019-11-29 at 3 09 38 PM](https://user-images.githubusercontent.com/3207297/69888623-dd0c2880-12ba-11ea-8276-c488a59bac31.png)

Heres what the proposed changes look like
![Screen Shot 2019-11-29 at 3 09 57 PM](https://user-images.githubusercontent.com/3207297/69888630-e5646380-12ba-11ea-9ba2-b7133fa67bff.png)
