### PR TITLE
GH-176 Replace GitHub usernames in body of notifications

### DIFF
--- a/server/template.go
+++ b/server/template.go
@@ -11,10 +11,10 @@ import (
 )
 
 const mdCommentRegexPattern string = `(<!--[\S\s]+?-->)`
-const gitHubRegexPattern string = `(^|[^_\x60[:alnum:]])(@[[:alnum:]](-?[[:alnum:]]+)*)`
+const gitHubUsernameRegexPattern string = `(^|[^_\x60[:alnum:]])(@[[:alnum:]](-?[[:alnum:]]+)*)`
 
 var mdCommentRegex = regexp.MustCompile(mdCommentRegexPattern)
-var gitHubRegex = regexp.MustCompile(gitHubRegexPattern)
+var gitHubUsernameRegex = regexp.MustCompile(gitHubUsernameRegexPattern)
 var masterTemplate *template.Template
 var gitHubToUsernameMappingCallback func(string) string
 
@@ -48,7 +48,7 @@ func init() {
 
 	// Replace any GitHub username with its corresponding Mattermost username, if any
 	funcMap["replaceAllGitHubUsernames"] = func(body string) string {
-		return gitHubRegex.ReplaceAllStringFunc(body, func(matched string) string {
+		return gitHubUsernameRegex.ReplaceAllStringFunc(body, func(matched string) string {
 			// The matched string contains the @ sign, and may contain a single
 			// character prepending the whole thing.
 			gitHubUsernameFirstCharIndex := strings.LastIndex(matched, "@") + 1

--- a/server/template.go
+++ b/server/template.go
@@ -11,6 +11,18 @@ import (
 )
 
 const mdCommentRegexPattern string = `(<!--[\S\s]+?-->)`
+
+// There is no public documentation of what constitutes a GitHub username, but
+// according to the error messages returned in https://github.com/join, it must:
+//   1. be between 1 and 39 characters long.
+//   2. contain only alphanumeric characters or non-adjacent hyphens.
+//   3. not begin or end with a hyphen.
+// When matching a valid GitHub username in the body of messages, it must:
+//   4. not be preceded by an underscore, a backtick (that cryptic \x60) or an
+//      alphanumeric character.
+// Ensuring the maximum length is not trivial without lookaheads, so this
+// regexp ensures only the minimum length, besides points 2, 3 and 4.
+// Note that the username, with the @ sign, is in the second capturing group.
 const gitHubUsernameRegexPattern string = `(^|[^_\x60[:alnum:]])(@[[:alnum:]](-?[[:alnum:]]+)*)`
 
 var mdCommentRegex = regexp.MustCompile(mdCommentRegexPattern)

--- a/server/template.go
+++ b/server/template.go
@@ -11,8 +11,10 @@ import (
 )
 
 const mdCommentRegexPattern string = `(<!--[\S\s]+?-->)`
+const gitHubRegexPattern string = `(^|[^_\x60[:alnum:]])(@[[:alnum:]](-?[[:alnum:]]+)*)`
 
 var mdCommentRegex = regexp.MustCompile(mdCommentRegexPattern)
+var gitHubRegex = regexp.MustCompile(gitHubRegexPattern)
 var masterTemplate *template.Template
 var gitHubToUsernameMappingCallback func(string) string
 
@@ -42,6 +44,24 @@ func init() {
 			return ""
 		}
 		return mdCommentRegex.ReplaceAllString(body, "")
+	}
+
+	// Replace any GitHub username with its corresponding Mattermost username, if any
+	funcMap["replaceAllGitHubUsernames"] = func(body string) string {
+		return gitHubRegex.ReplaceAllStringFunc(body, func(matched string) string {
+			// The matched string contains the @ sign, and may contain a single
+			// character prepending the whole thing.
+			gitHubUsernameFirstCharIndex := strings.LastIndex(matched, "@") + 1
+			prefix := matched[:gitHubUsernameFirstCharIndex]
+			gitHubUsername := matched[gitHubUsernameFirstCharIndex:]
+
+			username := lookupMattermostUsername(gitHubUsername)
+			if username == "" {
+				return matched
+			}
+
+			return prefix + username
+		})
 	}
 
 	masterTemplate = template.Must(template.New("master").Funcs(funcMap).Parse(""))
@@ -117,7 +137,7 @@ func init() {
 ##### {{template "eventRepoPullRequest" .}}
 #new-pull-request by {{template "user" .GetSender}}
 
-{{.GetPullRequest.GetBody | removeComments}}
+{{.GetPullRequest.GetBody | removeComments | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("closedPR").Funcs(funcMap).Parse(`
@@ -138,7 +158,7 @@ func init() {
 ##### {{template "eventRepoIssue" .}}
 #new-issue by {{template "user" .GetSender}}
 
-{{.GetIssue.GetBody | removeComments}}
+{{.GetIssue.GetBody | removeComments | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("closedIssue").Funcs(funcMap).Parse(`
@@ -169,7 +189,7 @@ func init() {
 	template.Must(masterTemplate.New("issueComment").Funcs(funcMap).Parse(`
 {{template "repo" .GetRepo}} New comment by {{template "user" .GetSender}} on {{template "issue" .Issue}}:
 
-{{.GetComment.GetBody | trimBody}}
+{{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("pullRequestReviewEvent").Funcs(funcMap).Parse(`
@@ -179,24 +199,24 @@ func init() {
 {{- else if eq .GetReview.GetState "CHANGES_REQUESTED"}} requested changes on
 {{- end }} {{template "pullRequest" .GetPullRequest}}:
 
-{{.Review.GetBody}}
+{{.Review.GetBody | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("newReviewComment").Funcs(funcMap).Parse(`
 {{template "repo" .GetRepo}} New review comment by {{template "user" .GetSender}} on {{template "pullRequest" .GetPullRequest}}:
 
 {{.GetComment.GetDiffHunk}}
-{{.GetComment.GetBody | trimBody}}
+{{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("commentMentionNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} mentioned you on [{{.GetRepo.GetFullName}}#{{.Issue.GetNumber}}]({{.GetComment.GetHTMLURL}}) - {{.Issue.GetTitle}}:
->{{.GetComment.GetBody | trimBody}}
+>{{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("commentAuthorPullRequestNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} commented on your pull request {{template "eventRepoIssueFullLinkWithTitle" .}}:
->{{.GetComment.GetBody | trimBody}}
+>{{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
 `))
 
 	template.Must(masterTemplate.New("commentAuthorIssueNotification").Funcs(funcMap).Parse(`
@@ -229,7 +249,7 @@ func init() {
 {{- else if eq .GetReview.GetState "changes_requested" }} requested changes on your pull request
 {{- else if eq .GetReview.GetState "commented" }} commented on your pull request
 {{- end }} {{template "reviewRepoPullRequestWithTitle" .}}
->{{.Review.GetBody}}
+>{{.Review.GetBody | replaceAllGitHubUsernames}}
 `))
 }
 

--- a/server/template.go
+++ b/server/template.go
@@ -34,13 +34,7 @@ func init() {
 	}
 
 	// Resolve a GitHub username to the corresponding Mattermost username, if linked.
-	funcMap["lookupMattermostUsername"] = func(githubUsername string) string {
-		if gitHubToUsernameMappingCallback == nil {
-			return ""
-		}
-
-		return gitHubToUsernameMappingCallback(githubUsername)
-	}
+	funcMap["lookupMattermostUsername"] = lookupMattermostUsername
 
 	// Trim away markdown comments in the text
 	funcMap["removeComments"] = func(body string) string {
@@ -241,6 +235,14 @@ func init() {
 
 func registerGitHubToUsernameMappingCallback(callback func(string) string) {
 	gitHubToUsernameMappingCallback = callback
+}
+
+func lookupMattermostUsername(githubUsername string) string {
+	if gitHubToUsernameMappingCallback == nil {
+		return ""
+	}
+
+	return gitHubToUsernameMappingCallback(githubUsername)
 }
 
 func renderTemplate(name string, data interface{}) (string, error) {

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -39,7 +39,7 @@ var pullRequestWithMentions = github.PullRequest{
 	CreatedAt: tToP(time.Date(2019, 04, 01, 02, 03, 04, 0, time.UTC)),
 	UpdatedAt: tToP(time.Date(2019, 05, 01, 02, 03, 04, 0, time.UTC)),
 	Body: sToP(`<!-- Thank you for opening this pull request-->git-get-head gets the non-sent upstream heads inside the stashed non-cleaned applied areas, and after pruning bases to many archives, you can initialize the origin of the bases.
-` + usernameMentions + `
+` + gitHubMentions + `
 <!-- Please make sure you have done the following :
 - Added tests
 - Removed console logs

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -1079,11 +1079,11 @@ func TestGitHubUsernameRegex(t *testing.T) {
 	}
 
 	for string, match := range stringAndMatchMap {
-		require.Equal(t, match, gitHubRegex.FindStringSubmatch(string)[2])
+		require.Equal(t, match, gitHubUsernameRegex.FindStringSubmatch(string)[2])
 	}
 
 	for _, string := range invalidUsernames {
-		require.False(t, gitHubRegex.MatchString(string))
+		require.False(t, gitHubUsernameRegex.MatchString(string))
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a function to the template generation process that matches all Github usernames and replaces them with their assigned Mattermost usernames, if any.

The regular expression to match the GitHub usernames is the following:

```
(^|[^_\x60[:alnum:]])(@[[:alnum:]](-?[[:alnum:]]+)*)
\___________________/ \__________/\_______________/
         (1)             (2.1)           (2.2)
                     \_____________________________/
                                    (2)
```

- The first matching group, (1), matches the beginning of the line or a character that is allowed to precede a GitHub username; i.e., any character different than underscore, backtick or an alphanumeric character.
- The second matching group, (2), wraps the matched GitHub username. Notice that there is no limit on its maximum length (39 at the moment), but in the rare case that we would match a string with more than 39 characters, we would not have any mapping to a Mattermost user, so the string will remain unchanged.
    - The (2.1) part makes sure that the username begins with a letter and is at least 1 character long.
    - The (2.2) part allows dashes, if and only if they are immediately followed by a non-empty string of alphanumeric characters. This can be repeated as many times as needed.

The matched strings contain the preceding character, if any. As there is no `ReplaceAllStringFunc` that accepts a function receiving the slice of submatches (see https://github.com/golang/go/issues/5690),  I needed to split the matched string, in the `replaceAllGitHubUsernames` function, into the prefix and the username itself, which we then lookup using the `lookupMattermostUsername` function.

The `replaceAllGitHubUsernames` function is applied to the following templates, when writing the body of the notification:
  - `newPR`
  - `newIssue`
  - `issueComment`
  - `pullRequestReviewEvent`
  - `newReviewComment`
  - `commentMentionNotification`
  - `commentAuthorPullRequestNotification`
  - `pullRequestReviewNotification`

I have also changed the unit tests in `template_test.go`:
- I have adapted the tests for the corresponding templates, adding an additional `"with mentions"` test that contains the usernames in the `usernameMap` keys, that maps GitHub usernames to Mattermost ones. The string with the values of this map is then used as the expected value in the tests. I did it this way so if we need to add an edge case for a GitHub username in the future, we can just modify the map and let the tests themselves unchanged.
- I have also added a unit test for the GitHub regular expression.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/176

