### PR TITLE
Fix template so `>` is not displayed if review body is empty

### DIFF
--- a/server/template.go
+++ b/server/template.go
@@ -261,8 +261,8 @@ func init() {
 {{- else if eq .GetReview.GetState "changes_requested" }} requested changes on your pull request
 {{- else if eq .GetReview.GetState "commented" }} commented on your pull request
 {{- end }} {{template "reviewRepoPullRequestWithTitle" .}}
->{{.Review.GetBody | replaceAllGitHubUsernames}}
-`))
+{{if .GetReview.GetBody}}>{{.Review.GetBody | replaceAllGitHubUsernames}}
+{{else}}{{end}}`))
 }
 
 func registerGitHubToUsernameMappingCallback(callback func(string) string) {

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -1047,6 +1047,23 @@ func TestPullRequestReviewNotification(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	}))
+	t.Run("review with no body", withGitHubUserNameMapping(func(t *testing.T) {
+		expected := `
+@pandabot approved your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456) - Leverage git-get-head
+`
+
+		actual, err := renderTemplate("pullRequestReviewNotification", &github.PullRequestReviewEvent{
+			Repo:        &repo,
+			PullRequest: &pullRequest,
+			Sender:      &user,
+			Review: &github.PullRequestReview{
+				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456"),
+				State:   sToP("approved"),
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}))
 }
 
 func TestGitHubUsernameRegex(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR makes it such that '>' is not displayed if the review body is empty

#### Ticket Link
Resolves #185 
