### PR TITLE
No longer mention the author of an event in the channel #108

### DIFF
--- a/server/template.go
+++ b/server/template.go
@@ -82,7 +82,7 @@ func init() {
 	// Mattermost user, their Mattermost handle is referenced as an at-mention instead.
 	template.Must(masterTemplate.New("user").Parse(`
 {{- $mattermostUsername := .GetLogin | lookupMattermostUsername}}
-{{- if $mattermostUsername }}@{{$mattermostUsername}}
+{{- if $mattermostUsername }}{{$mattermostUsername}}
 {{- else}}[{{.GetLogin}}]({{.GetHTMLURL}})
 {{- end -}}
 	`))

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -152,7 +152,7 @@ func TestUserTemplate(t *testing.T) {
 	})
 
 	t.Run("Mattermost username", withGitHubUserNameMapping(func(t *testing.T) {
-		expected := "@pandabot"
+		expected := "pandabot"
 		actual, err := renderTemplate("user", &user)
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
@@ -184,7 +184,7 @@ git-get-head gets the non-sent upstream heads inside the stashed non-cleaned app
 		expected := `
 #### Leverage git-get-head
 ##### [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42)
-#new-pull-request by @pandabot
+#new-pull-request by pandabot
 
 git-get-head gets the non-sent upstream heads inside the stashed non-cleaned applied areas, and after pruning bases to many archives, you can initialize the origin of the bases.
 ` + usernameMentions + `
@@ -273,7 +273,7 @@ git-get-head sounds like a great feature we should support
 		expected := `
 #### Implement git-get-head
 ##### [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1)
-#new-issue by @pandabot
+#new-issue by pandabot
 
 git-get-head sounds like a great feature we should support
 ` + usernameMentions + `
@@ -530,7 +530,7 @@ git-get-head sounds like a great feature we should support
 
 	t.Run("non-email body with mentions", withGitHubUserNameMapping(func(t *testing.T) {
 		expected := `
-[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) New comment by @pandabot on [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1):
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) New comment by pandabot on [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1):
 
 git-get-head sounds like a great feature we should support
 ` + usernameMentions + `
@@ -550,7 +550,7 @@ git-get-head sounds like a great feature we should support
 
 	t.Run("email body with mentions", withGitHubUserNameMapping(func(t *testing.T) {
 		expected := `
-[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) New comment by @pandabot on [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1):
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) New comment by pandabot on [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1):
 
 git-get-head sounds like a great feature we should support
 ` + usernameMentions + `

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -632,7 +632,7 @@ Excited to see git-get-head land!
 
 	t.Run("approved with mentions", withGitHubUserNameMapping(func(t *testing.T) {
 		expected := `
-[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) @pandabot approved [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42):
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) pandabot approved [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42):
 
 Excited to see git-get-head land!
 ` + usernameMentions + `
@@ -676,7 +676,7 @@ Should this be here?
 
 	t.Run("with mentions", withGitHubUserNameMapping(func(*testing.T) {
 		expected := `
-[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) New review comment by @pandabot on [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42):
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) New review comment by pandabot on [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42):
 
 HUNK
 Should this be here?
@@ -738,7 +738,7 @@ func TestCommentMentionNotificationTemplate(t *testing.T) {
 
 	t.Run("non-email body with mentions", withGitHubUserNameMapping(func(t *testing.T) {
 		expected := `
-@pandabot mentioned you on [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
+pandabot mentioned you on [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
 >@cpanato, anytime?
 ` + usernameMentions + `
 `
@@ -758,7 +758,7 @@ func TestCommentMentionNotificationTemplate(t *testing.T) {
 
 	t.Run("email body with mentions", withGitHubUserNameMapping(func(t *testing.T) {
 		expected := `
-@pandabot mentioned you on [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
+pandabot mentioned you on [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
 >@cpanato, anytime?
 ` + usernameMentions + `
 `
@@ -800,7 +800,7 @@ func TestCommentAuthorPullRequestNotificationTemplate(t *testing.T) {
 
 	t.Run("with mentions", withGitHubUserNameMapping(func(*testing.T) {
 		expected := `
-@pandabot commented on your pull request [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
+pandabot commented on your pull request [mattermost-plugin-github#1](https://github.com/mattermost/mattermost-plugin-github/issues/1/comment/3) - Implement git-get-head:
 >@cpanato, anytime?
 ` + usernameMentions + `
 `
@@ -1029,7 +1029,7 @@ func TestPullRequestReviewNotification(t *testing.T) {
 	})
 	t.Run("approved with mentions", withGitHubUserNameMapping(func(t *testing.T) {
 		expected := `
-@pandabot approved your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456) - Leverage git-get-head
+pandabot approved your pull request [mattermost-plugin-github#42](https://github.com/mattermost/mattermost-plugin-github/pull/42#issuecomment-123456) - Leverage git-get-head
 >Excited to see git-get-head land!
 ` + usernameMentions + `
 `


### PR DESCRIPTION
Right now we mention the user, who is the author of an event like "the one pushed an commit" in the channel and notify her/him about his own change, triggering a notification on the mobile phone, desktop notification and all this.

This is fairly intrusive and without any value to the user, since she/he is the author of the immediate action and already knows about it

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

