### PR TITLE
[MM-22697] Replace Github with GitHub everywhere

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -28,7 +28,7 @@ const COMMAND_HELP = `* |/github connect| - Connect your Mattermost account to y
 	* label:"<labelname>" - must include "pulls" or "issues" in feature list when using a label
 	Defaults to "pulls,issues,creates,deletes"
   * |flags| currently supported:
-    * --exclude-org-member - events triggered by organization members will not be delivered (the Github organization config
+    * --exclude-org-member - events triggered by organization members will not be delivered (the GitHub organization config
 		should be set, otherwise this flag has not effect)
 * |/github unsubscribe owner/repo| - Unsubscribe the current channel from a repository
 * |/github me| - Display the connected GitHub account
@@ -78,8 +78,8 @@ func validateFeatures(features []string) (bool, []string) {
 func getCommand() *model.Command {
 	return &model.Command{
 		Trigger:          "github",
-		DisplayName:      "Github",
-		Description:      "Integration with Github.",
+		DisplayName:      "GitHub",
+		Description:      "Integration with GitHub.",
 		AutoComplete:     true,
 		AutoCompleteDesc: "Available commands: connect, disconnect, todo, me, settings, subscribe, unsubscribe, help",
 		AutoCompleteHint: "[command]",

--- a/server/template_test.go
+++ b/server/template_test.go
@@ -84,7 +84,7 @@ var user = github.User{
 	HTMLURL: sToP("https://github.com/panda"),
 }
 
-// A map of known associations between Github users and Mattermost users
+// A map of known associations between GitHub users and Mattermost users
 var usernameMap = map[string]string{
 	"panda":          "pandabot",
 	"asaadmahmood":   "asaad.mahmood",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "version": "0.10.2",
-  "description": "Github plugin for Mattermost",
+  "description": "GitHub plugin for Mattermost",
   "main": "src/index.js",
   "scripts": {
     "build": "webpack --mode=production --display-error-details --progress",

--- a/webapp/src/components/github_issue_selector.jsx
+++ b/webapp/src/components/github_issue_selector.jsx
@@ -125,7 +125,7 @@ export default class GithubIssueSelector extends PureComponent {
                     className={'control-label'}
                     htmlFor={'issue'}
                 >
-                    {'Github Issue'}
+                    {'GitHub Issue'}
                 </label>
                 {this.props.required && requiredStar}
                 <AsyncSelect

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -28,7 +28,7 @@ class PluginClass {
         registry.registerRootComponent(AttachCommentToIssueModal);
         registry.registerPostDropdownMenuComponent(AttachCommentToIssuePostMenuAction);
 
-        const {showRHSPlugin} = registry.registerRightHandSidebarComponent(SidebarRight, 'Github Plugin');
+        const {showRHSPlugin} = registry.registerRightHandSidebarComponent(SidebarRight, 'GitHub');
         store.dispatch(setShowRHSAction(() => store.dispatch(showRHSPlugin)));
 
         registry.registerWebSocketEventHandler('custom_github_connect', handleConnect(store));


### PR DESCRIPTION
#### Summary
Replace `Github` with `GitHub` everywhere in the code

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22697
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/175

