### PR TITLE
Require read:org scope for OAuth connect

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -159,16 +159,16 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 	authURL.Path = path.Join(authURL.Path, "login", "oauth", "authorize")
 	tokenURL.Path = path.Join(tokenURL.Path, "login", "oauth", "access_token")
 
-	repo := "public_repo"
+	repo := github.ScopePublicRepo
 	if config.EnablePrivateRepo {
-		// means that asks scope for privaterepositories
-		repo = "repo"
+		// means that asks scope for private repositories
+		repo = github.ScopeRepo
 	}
 
 	return &oauth2.Config{
 		ClientID:     config.GitHubOAuthClientID,
 		ClientSecret: config.GitHubOAuthClientSecret,
-		Scopes:       []string{repo, string(github.ScopeNotifications), string(github.ScopeReadOrg)},
+		Scopes:       []string{string(repo), string(github.ScopeNotifications), string(github.ScopeReadOrg)},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  authURL.String(),
 			TokenURL: tokenURL.String(),

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -168,7 +168,7 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     config.GitHubOAuthClientID,
 		ClientSecret: config.GitHubOAuthClientSecret,
-		Scopes:       []string{repo, "notifications"},
+		Scopes:       []string{repo, string(github.ScopeNotifications), string(github.ScopeReadOrg)},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  authURL.String(),
 			TokenURL: tokenURL.String(),


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-plugin-github/pull/154 did add a feature flag `--exclude-org-member` to subscriptions, which allows to ignore events from organization members. Currently, the oauth scope doesn't include information about the membership of the user. This PR fixes it by broadening the scope.

To apply this fix to a given subscription the user who created it has to disconnect and reconnect the MM account to GitHub.

I've tested my changes with ngrok and a test organisation.

#### QA test steps
1. Create two users and connect them both to the github via `github connect`
2. Create an organization ORG and let both users join it
3. Make sure organization visibility is set to "private" for user B
4. As user A create a subscription to ORG using `--exclude-org-member`
5. As user B create an issue to trigger the subscription
6. Confirm no notification is shown in MM

@DHaussermann If you need help testing this, just let me know.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/199
