### PR TITLE
Add user validation for repo and title fields

### DIFF
--- a/webapp/src/components/github_repo_selector.jsx
+++ b/webapp/src/components/github_repo_selector.jsx
@@ -19,19 +19,22 @@ export default class GithubRepoSelector extends PureComponent {
         theme: PropTypes.object.isRequired,
         onChange: PropTypes.func.isRequired,
         value: PropTypes.object,
+        showErrors: PropTypes.bool,
     };
 
     constructor(props) {
         super(props);
 
         this.state = {
-            invalid: false,
+            invalid: true,
             error: null,
         };
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (prevState.invalid && this.props.value !== prevProps.value) {
+        // check prevProps against current props value to ensure validationError
+        // doesn't show on initial component rendering
+        if (prevState.invalid && this.props.value && (this.props.value.full_name !== prevProps.value.full_name)) {
             this.setState({invalid: false}); //eslint-disable-line react/no-did-update-set-state
         }
     }
@@ -91,7 +94,7 @@ export default class GithubRepoSelector extends PureComponent {
 
         const requiredMsg = 'This field is required.';
         let validationError = null;
-        if (this.props.required && this.state.invalid) {
+        if (this.props.showErrors && this.props.required && this.state.invalid) {
             validationError = (
                 <p className='help-text error-text'>
                     <span>{requiredMsg}</span>

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -14,6 +14,8 @@ const initialState = {
     error: null,
     repoValue: '',
     issueTitle: '',
+    showErrors: false,
+    issueTitleValid: true,
 };
 
 export default class CreateIssueModal extends PureComponent {
@@ -36,7 +38,10 @@ export default class CreateIssueModal extends PureComponent {
             e.preventDefault();
         }
 
-        if (!this.state.issueTitle) {
+        if (!this.state.issueTitle || !this.state.repoValue) {
+            const isValid = Boolean(this.state.issueTitle);
+            this.setState({issueTitleValid: isValid});
+            this.setState({showErrors: true});
             return;
         }
 
@@ -82,6 +87,16 @@ export default class CreateIssueModal extends PureComponent {
         const {error, submitting} = this.state;
         const style = getStyle(theme);
 
+        const requiredMsg = 'This field is required.';
+        let issueTitleValidationError = null;
+        if (this.state.showErrors && !this.state.issueTitleValid) {
+            issueTitleValidationError = (
+                <p className='help-text error-text'>
+                    <span>{requiredMsg}</span>
+                </p>
+            );
+        }
+
         if (!visible) {
             return null;
         }
@@ -103,6 +118,7 @@ export default class CreateIssueModal extends PureComponent {
                     required={true}
                     theme={theme}
                     value={this.state.repoValue}
+                    showErrors={this.state.showErrors}
                 />
                 <Input
                     id={'title'}
@@ -114,6 +130,7 @@ export default class CreateIssueModal extends PureComponent {
                     value={this.state.issueTitle}
                     onChange={this.handleIssueTitleChange}
                 />
+                {issueTitleValidationError}
                 <Input
                     label='Description for the GitHub Issue'
                     type='textarea'


### PR DESCRIPTION
#### Summary
This PR resolves two issues with the new Create Issue Modal where field validation is necessary.  

1) #216 No validation if Title is left empty
2) #215 Submit hangs if the repository is left empty

#### Ticket Link
Fixes #216 
Fixes #215 

#### Images
![image](https://user-images.githubusercontent.com/7575921/77608573-a69e8d00-6eeb-11ea-84b2-2feb54b7bda5.png)
