### PR TITLE
Drop PluginsDirectory from config

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/pkg/errors"
 )
 
@@ -28,7 +27,6 @@ type configuration struct {
 	EncryptionKey           string
 	EnterpriseBaseURL       string
 	EnterpriseUploadURL     string
-	PluginsDirectory        string
 	EnableCodePreview       bool
 }
 
@@ -79,7 +77,7 @@ func (p *Plugin) getConfiguration() *configuration {
 // This method panics if setConfiguration is called with the existing configuration. This almost
 // certainly means that the configuration was modified without being cloned and may result in
 // an unsafe access.
-func (p *Plugin) setConfiguration(configuration *configuration, serverConfiguration *model.Config) {
+func (p *Plugin) setConfiguration(configuration *configuration) {
 	p.configurationLock.Lock()
 	defer p.configurationLock.Unlock()
 
@@ -94,11 +92,6 @@ func (p *Plugin) setConfiguration(configuration *configuration, serverConfigurat
 		panic("setConfiguration called with the existing configuration")
 	}
 
-	// PluginDirectory should be set based on server configuration and not the plugin configuration
-	if serverConfiguration.PluginSettings.Directory != nil {
-		configuration.PluginsDirectory = *serverConfiguration.PluginSettings.Directory
-	}
-
 	p.configuration = configuration
 }
 
@@ -111,9 +104,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		return errors.Wrap(err, "failed to load plugin configuration")
 	}
 
-	serverConfiguration := p.API.GetConfig()
-
-	p.setConfiguration(configuration, serverConfiguration)
+	p.setConfiguration(configuration)
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
Drop PluginsDirectory from config as it's not longer needed.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/249
