### PR TITLE
Attaching a message to an issue links to GitHub account, not MM account

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -775,8 +775,9 @@ func (p *Plugin) createIssueComment(w http.ResponseWriter, r *http.Request, user
 		rootId = post.RootId
 	}
 
+	permalinkReplyMessage := fmt.Sprintf("Message attached to [#%v](https://github.com/%v/%v/issues/%v)", req.Number, req.Owner, req.Repo, req.Number)
 	reply := &model.Post{
-		Message:   fmt.Sprintf("Message attached to [#%v](https://github.com/%v/%v/issues/%v)", req.Number, req.Owner, req.Repo, req.Number),
+		Message:   permalinkReplyMessage,
 		ChannelId: post.ChannelId,
 		RootId:    rootId,
 		ParentId:  rootId,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
* Attaching a message to an issue links to GitHub account, not MM account
   - Instead of using the MM username, the username on GitHub is used. 
   - If the user whose message is attached is not connected to GitHub, then the MM username is used
* Added permalink to Message in reply, which is given after a user attaches a message to a GitHub issue
<!--
A description of what this pull request does.
-->

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-plugin-github/issues/253

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.
  Fixes https://github.com/mattermost/mattermost-plugin-github/issues/253
Otherwise, link the JIRA ticket.
-->

