### PR TITLE
Indicate if a PR has a conflict

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -45,6 +45,7 @@ type PRDetails struct {
 	URL                string                      `json:"url"`
 	Number             int                         `json:"number"`
 	Status             string                      `json:"status"`
+	Mergeable          bool                        `json:"mergeable"`
 	RequestedReviewers []*string                   `json:"requestedReviewers"`
 	Reviews            []*github.PullRequestReview `json:"reviews"`
 }
@@ -569,7 +570,8 @@ func (p *Plugin) getPrsDetails(w http.ResponseWriter, r *http.Request, userID st
 }
 
 func fetchPRDetails(ctx context.Context, client *github.Client, prURL string, prNumber int) *PRDetails {
-	status := ""
+	var status string
+	var mergeable bool
 	// Initialize to a non-nil slice to simplify JSON handling semantics
 	requestedReviewers := []*string{}
 	var reviewsList []*github.PullRequestReview = []*github.PullRequestReview{}
@@ -599,6 +601,9 @@ func fetchPRDetails(ctx context.Context, client *github.Client, prURL string, pr
 			mlog.Error(err.Error())
 			return
 		}
+
+		mergeable = prInfo.GetMergeable()
+
 		for _, v := range prInfo.RequestedReviewers {
 			requestedReviewers = append(requestedReviewers, v.Login)
 		}
@@ -615,6 +620,7 @@ func fetchPRDetails(ctx context.Context, client *github.Client, prURL string, pr
 		URL:                prURL,
 		Number:             prNumber,
 		Status:             status,
+		Mergeable:          mergeable,
 		RequestedReviewers: requestedReviewers,
 		Reviews:            reviewsList,
 	}

--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 
 import {Badge, Tooltip, OverlayTrigger} from 'react-bootstrap';
 import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
-import Octicon, {Alert} from '@primer/octicons-react';
 
 import {formatTimeSince} from 'utils/date_utils';
 
@@ -116,7 +115,10 @@ function GithubItems(props) {
                         </Tooltip>
                     }
                 >
-                    <i className='icon icon-alert-outline'/>
+                    <i
+                        style={style.conflictIcon}
+                        className='icon icon-alert-outline'
+                    />
                 </OverlayTrigger>
             );
         }
@@ -180,10 +182,13 @@ const getStyle = makeStyleFromTheme((theme) => {
         icon: {
             top: 3,
             position: 'relative',
-            left: 6,
+            left: 3,
             height: 18,
             display: 'inline-flex',
             alignItems: 'center',
+        },
+        conflictIcon: {
+            color: theme.errorTextColor,
         },
         milestoneIcon: {
             top: 3,

--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -116,13 +116,7 @@ function GithubItems(props) {
                         </Tooltip>
                     }
                 >
-                    <span>
-                        <Octicon
-                            icon={Alert}
-                            size='small'
-                            verticalAlign='middle'
-                        />
-                    </span>
+                    <i className='icon icon-alert-outline'/>
                 </OverlayTrigger>
             );
         }

--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import {Badge, Tooltip, OverlayTrigger} from 'react-bootstrap';
 import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
+import Octicon, {Alert} from '@primer/octicons-react';
 
 import {formatTimeSince} from 'utils/date_utils';
 
@@ -103,6 +104,29 @@ function GithubItems(props) {
             }
         }
 
+        let hasConflict = '';
+        if (item.mergeable != null && !item.mergeable) {
+            hasConflict = (
+                <OverlayTrigger
+                    key='githubRHSPRMergeableIndicator'
+                    placement='top'
+                    overlay={
+                        <Tooltip id='githubRHSPRMergeableTooltip'>
+                            {'This pull request has conflicts that must be resolved'}
+                        </Tooltip>
+                    }
+                >
+                    <span>
+                        <Octicon
+                            icon={Alert}
+                            size='small'
+                            verticalAlign='middle'
+                        />
+                    </span>
+                </OverlayTrigger>
+            );
+        }
+
         return (
             <div
                 key={item.id}
@@ -110,7 +134,7 @@ function GithubItems(props) {
             >
                 <div>
                     <strong>
-                        {title}{status}
+                        {title}{hasConflict}{status}
                     </strong>
                 </div>
                 <div>

--- a/webapp/src/components/sidebar_right/index.jsx
+++ b/webapp/src/components/sidebar_right/index.jsx
@@ -28,6 +28,7 @@ function mapPrsToDetails(prs, details) {
         return {
             ...pr,
             status: foundDetails.status,
+            mergeable: foundDetails.mergeable,
             requestedReviewers: foundDetails.requestedReviewers,
             reviews: foundDetails.reviews,
         };


### PR DESCRIPTION
#### Summary
Indicate on RHS, if the PR as a conflict. Please note that the PR status is always `pending` if there is a conflict. But that issue was present before this changes and is unrelated.

![Screenshot from 2020-05-29 07-34-48](https://user-images.githubusercontent.com/16541325/83235783-b9a33700-a192-11ea-8f95-04aa0a44391c.png)


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/225
