### PR TITLE
Fix Github > GitHub capitalization error

### DIFF
--- a/webapp/src/components/post_menu_action/create_issue/create_issue.jsx
+++ b/webapp/src/components/post_menu_action/create_issue/create_issue.jsx
@@ -35,7 +35,7 @@ export default class CreateIssuePostMenuAction extends PureComponent {
                 onClick={this.handleClick}
             >
                 <GitHubIcon type='menu'/>
-                {'Create Github Issue'}
+                {'Create GitHub Issue'}
             </button>
         );
 


### PR DESCRIPTION
0/5, is it possible to have a build check of some kind that detects an incorrect capitalization in future?

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

