### PR TITLE
[GH-283] Fix parsing multi-word labels in subscription command

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -258,7 +258,7 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 type CommandHandleFunc func(c *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	command, action, parameters := p.parseCommand(args.Command)
+	command, action, parameters := parseCommand(args.Command)
 
 	if command != "/github" {
 		return &model.CommandResponse{}, nil
@@ -316,7 +316,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 // parseCommand parses the entire command input string and retrieves the command, action and parameters
-func (p *Plugin) parseCommand(input string) (command, action string, parameters []string) {
+func parseCommand(input string) (command, action string, parameters []string) {
 	// do not split if the whitespace is in between 2 quotes, e.g. "Hello World"
 	foundQuote := false
 	split := strings.FieldsFunc(input, func(c rune) bool {

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -83,3 +83,72 @@ func TestValidateFeatures(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCommand(t *testing.T) {
+	type output struct {
+		command    string
+		action     string
+		parameters []string
+	}
+
+	tt := []struct {
+		name  string
+		input string
+		want  output
+	}{
+		{
+			name:  "no parameters",
+			input: "/github subscribe",
+			want: output{
+				"/github",
+				"subscribe",
+				[]string(nil),
+			},
+		},
+		{
+			name:  "no action and no parameters",
+			input: "/github",
+			want: output{
+				"/github",
+				"",
+				[]string(nil),
+			},
+		},
+		{
+			name:  "simple one-word label",
+			input: "/github subscribe DHaussermann/hello-world issues,label:\"Help\"",
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", "issues,label:\"Help\""},
+			},
+		},
+		{
+			name:  "two-word label",
+			input: "/github subscribe DHaussermann/hello-world issues,label:\"Help Wanted\"",
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", "issues,label:\"Help Wanted\""},
+			},
+		},
+		{
+			name:  "multi-word label",
+			input: "/github subscribe DHaussermann/hello-world issues,label:\"Good First Issue\"",
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", "issues,label:\"Good First Issue\""},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			command, action, parameters := parseCommand(tc.input)
+			got := output{command, action, parameters}
+			errMsg := fmt.Sprintf("validateFeatures() = %v, want %v", got, tc.want)
+			assert.EqualValues(t, tc.want, got, errMsg)
+		})
+	}
+}

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -44,32 +44,32 @@ func TestValidateFeatures(t *testing.T) {
 		},
 		{
 			name: "all features valid with label but issues and pulls missing",
-			args: []string{"pushes", "label:\"ruby\""},
+			args: []string{"pushes", `label:"ruby"`},
 			want: output{false, []string{}},
 		},
 		{
 			name: "all features valid with label and issues in features",
-			args: []string{"issues", "label:\"ruby\""},
+			args: []string{"issues", `label:"ruby"`},
 			want: output{true, []string{}},
 		},
 		{
 			name: "all features valid with label and pulls in features",
-			args: []string{"pulls", "label:\"ruby\""},
+			args: []string{"pulls", `label:"ruby"`},
 			want: output{true, []string{}},
 		},
 		{
 			name: "multiple features invalid with label but issues and pulls missing",
-			args: []string{"issue", "push", "label:\"ruby\""},
+			args: []string{"issue", "push", `label:"ruby"`},
 			want: output{false, []string{"issue", "push"}},
 		},
 		{
 			name: "multiple features invalid with label and issues in features",
-			args: []string{"issues", "push", "create", "label:\"ruby\""},
+			args: []string{"issues", "push", "create", `label:"ruby"`},
 			want: output{false, []string{"push", "create"}},
 		},
 		{
 			name: "multiple features invalid with label and pulls in features",
-			args: []string{"pulls", "push", "create", "label:\"ruby\""},
+			args: []string{"pulls", "push", "create", `label:"ruby"`},
 			want: output{false, []string{"push", "create"}},
 		},
 	}
@@ -116,29 +116,29 @@ func TestParseCommand(t *testing.T) {
 		},
 		{
 			name:  "simple one-word label",
-			input: "/github subscribe DHaussermann/hello-world issues,label:\"Help\"",
+			input: `/github subscribe DHaussermann/hello-world issues,label:"Help"`,
 			want: output{
 				"/github",
 				"subscribe",
-				[]string{"DHaussermann/hello-world", "issues,label:\"Help\""},
+				[]string{"DHaussermann/hello-world", `issues,label:"Help"`},
 			},
 		},
 		{
 			name:  "two-word label",
-			input: "/github subscribe DHaussermann/hello-world issues,label:\"Help Wanted\"",
+			input: `/github subscribe DHaussermann/hello-world issues,label:"Help Wanted"`,
 			want: output{
 				"/github",
 				"subscribe",
-				[]string{"DHaussermann/hello-world", "issues,label:\"Help Wanted\""},
+				[]string{"DHaussermann/hello-world", `issues,label:"Help Wanted"`},
 			},
 		},
 		{
 			name:  "multi-word label",
-			input: "/github subscribe DHaussermann/hello-world issues,label:\"Good First Issue\"",
+			input: `/github subscribe DHaussermann/hello-world issues,label:"Good First Issue"`,
 			want: output{
 				"/github",
 				"subscribe",
-				[]string{"DHaussermann/hello-world", "issues,label:\"Good First Issue\""},
+				[]string{"DHaussermann/hello-world", `issues,label:"Good First Issue"`},
 			},
 		},
 	}

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -177,6 +177,15 @@ func TestParseCommand(t *testing.T) {
 				[]string{"طماطم", `issues,label:"日本語"`},
 			},
 		},
+		{
+			name:  "line breaks",
+			input: "/github \nsubscribe\nDHaussermann/hello-world\nissues,label:\"Good First Issue\"",
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", `issues,label:"Good First Issue"`},
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -159,6 +159,24 @@ func TestParseCommand(t *testing.T) {
 				[]string{"DHaussermann/hello-world", `issues,label:"Help Wanted"`},
 			},
 		},
+		{
+			name:  "trailing whitespaces",
+			input: `/github subscribe DHaussermann/hello-world issues,label:"Help Wanted" `,
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", `issues,label:"Help Wanted"`},
+			},
+		},
+		{
+			name:  "non-ASCII characters",
+			input: `/github subscribe طماطم issues,label:"日本語"`,
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"طماطم", `issues,label:"日本語"`},
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -141,6 +141,24 @@ func TestParseCommand(t *testing.T) {
 				[]string{"DHaussermann/hello-world", `issues,label:"Good First Issue"`},
 			},
 		},
+		{
+			name:  "multiple spaces inside double-quotes",
+			input: `/github subscribe DHaussermann/hello-world issues,label:"Help    Wanted"`,
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", `issues,label:"Help    Wanted"`},
+			},
+		},
+		{
+			name:  "multiple spaces outside of double-quotes",
+			input: `  /github    subscribe     DHaussermann/hello-world issues,label:"Help Wanted"`,
+			want: output{
+				"/github",
+				"subscribe",
+				[]string{"DHaussermann/hello-world", `issues,label:"Help Wanted"`},
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
#### Summary
This PR will update the command parser such that it will skip whitespaces in two double-quotes. This will fix the related bug by protecting the integrity of multi-word labels such as "Help Wanted".

#### Ticket Link
Fixes #283 

