### PR TITLE
Break text in link tooltip

### DIFF
--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -72,6 +72,7 @@
     max-height: 150px;
     line-height: 1.25;
     overflow: hidden;
+    word-break: break-all;
     font-size: 12px;
 }
 


### PR DESCRIPTION
#### Summary
**Before:**
![Screenshot from 2020-07-30 15-52-24](https://user-images.githubusercontent.com/16541325/88931241-ddf7be80-d27c-11ea-8ef6-6e2fb6f22e10.png)

**After:**
![Screenshot from 2020-07-30 15-50-28](https://user-images.githubusercontent.com/16541325/88931068-a12bc780-d27c-11ea-9c49-af24209f34ef.png)


#### Ticket Link
https://github.com/mattermost/mattermost-plugin-github/issues/330

