### PR TITLE
Add dropdown setting for Code Preview

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -71,8 +71,23 @@
             {
                 "key": "EnableCodePreview",
                 "display_name": "Enable Code Previews",
-                "type": "bool",
-                "help_text": "(Optional) Allow the plugin to expand permalinks to github files with an actual preview of the linked file."
+                "type": "dropdown",
+                "help_text": "Allow the plugin to expand permalinks to GitHub files with an actual preview of the linked file.",
+                "default": "public",
+                "options": [
+                    {
+                        "display_name": "Enable for public repositories",
+                        "value": "public"
+                    },
+                    {
+                        "display_name": "Enable for public and private repositories. This might leak confidential code into public channels.",
+                        "value": "privateAndPublic"
+                    },
+                    {
+                        "display_name": "Disable",
+                        "value": "disable"
+                    }
+                ]
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -68,7 +68,7 @@ func TestPlugin_ServeHTTP(t *testing.T) {
 					EncryptionKey:           "mockKey",
 					EnterpriseBaseURL:       "",
 					EnterpriseUploadURL:     "",
-					EnableCodePreview:       false,
+					EnableCodePreview:       "disable",
 				})
 			p.initializeAPI()
 			p.SetAPI(&plugintest.API{})

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -26,7 +26,7 @@ type Configuration struct {
 	EncryptionKey           string
 	EnterpriseBaseURL       string
 	EnterpriseUploadURL     string
-	EnableCodePreview       bool
+	EnableCodePreview       string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -164,7 +164,7 @@ func (p *Plugin) OnActivate() error {
 func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*model.Post, string) {
 	// If not enabled in config, ignore.
 	config := p.getConfiguration()
-	if !config.EnableCodePreview {
+	if config.EnableCodePreview == "disable" {
 		return nil, ""
 	}
 


### PR DESCRIPTION
#### Summary
![Screenshot from 2020-08-07 12-32-33](https://user-images.githubusercontent.com/16541325/89637184-16655100-d8aa-11ea-9e14-14f577f4e18e.png)

Add a dropdown to the system console to set the level for which code preview is enabled. By default, it's enabled for public repos.

Installations that had Code Preview enabled before will now only have it enabled for public repo. That seams like a fine solution as the security implications were not clear for admin in the past.


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/323
