### PR TITLE
Avoided panic on empty body of PR and Issue

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -946,7 +946,9 @@ func (p *Plugin) getIssueByNumber(w http.ResponseWriter, r *http.Request, userID
 		p.writeAPIError(w, &APIErrorResponse{Message: "Could not get issue", StatusCode: http.StatusInternalServerError})
 		return
 	}
-	*result.Body = mdCommentRegex.ReplaceAllString(result.GetBody(), "")
+	if result.Body != nil {
+		*result.Body = mdCommentRegex.ReplaceAllString(result.GetBody(), "")
+	}
 	p.writeJSON(w, result)
 }
 
@@ -983,7 +985,9 @@ func (p *Plugin) getPrByNumber(w http.ResponseWriter, r *http.Request, userID st
 		p.writeAPIError(w, &APIErrorResponse{Message: "Could not get pull request", StatusCode: http.StatusInternalServerError})
 		return
 	}
-	*result.Body = mdCommentRegex.ReplaceAllString(result.GetBody(), "")
+	if result.Body != nil {
+		*result.Body = mdCommentRegex.ReplaceAllString(result.GetBody(), "")
+	}
 	p.writeJSON(w, result)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Checks whether pointer to the body of PR/Issue is `nil` before accessing it to avoid panic.
- I have assumed that `result` obtained by calling `Get()` on PR/Issue is never `nil` as other functions do not check this condition (Reference: https://github.com/mattermost/mattermost-plugin-github/blob/master/server/plugin/api.go#L489).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Extension to the PR https://github.com/mattermost/mattermost-plugin-github/pull/326 that fixes https://github.com/mattermost/mattermost-plugin-github/issues/312
