### PR TITLE
Migrate logging to use RPC Logging methods

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -7,7 +7,6 @@ import (
 	"unicode"
 
 	"github.com/google/go-github/v31/github"
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
@@ -176,7 +175,7 @@ func (p *Plugin) handleUnsubscribe(_ *plugin.Context, args *model.CommandArgs, p
 	repo := parameters[0]
 
 	if err := p.Unsubscribe(args.ChannelId, repo); err != nil {
-		mlog.Error(err.Error())
+		p.API.LogWarn("Failed to unsubscribe", "repo", repo, "error", err.Error())
 		return "Encountered an error trying to unsubscribe. Please try again."
 	}
 
@@ -193,7 +192,7 @@ func (p *Plugin) handleTodo(_ *plugin.Context, _ *model.CommandArgs, _ []string,
 
 	text, err := p.GetToDo(context.Background(), userInfo.GitHubUsername, githubClient)
 	if err != nil {
-		mlog.Error(err.Error())
+		p.API.LogWarn("Failed get get Todos", "error", err.Error())
 		return "Encountered an error getting your to do items."
 	}
 	return text
@@ -213,7 +212,7 @@ func (p *Plugin) handleMe(_ *plugin.Context, _ *model.CommandArgs, _ []string, u
 func (p *Plugin) handleHelp(_ *plugin.Context, _ *model.CommandArgs, _ []string, _ *GitHubUserInfo) string {
 	message, err := renderTemplate("helpText", p.getConfiguration())
 	if err != nil {
-		p.API.LogWarn("failed to render help template", "error", err.Error())
+		p.API.LogWarn("Failed to render help template", "error", err.Error())
 		return "Encountered an error posting help text."
 	}
 
@@ -242,12 +241,18 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 		if value {
 			err := p.storeGitHubToUserIDMapping(userInfo.GitHubUsername, userInfo.UserID)
 			if err != nil {
-				mlog.Error(err.Error())
+				p.API.LogWarn("Failed to store GitHub to userID mapping",
+					"userID", userInfo.UserID,
+					"GitHub username", userInfo.GitHubUsername,
+					"error", err.Error())
 			}
 		} else {
 			err := p.API.KVDelete(userInfo.GitHubUsername + githubUsernameKey)
 			if err != nil {
-				mlog.Error(err.Error())
+				p.API.LogWarn("Failed to delete GitHub to userID mapping",
+					"userID", userInfo.UserID,
+					"GitHub username", userInfo.GitHubUsername,
+					"error", err.Error())
 			}
 		}
 
@@ -258,7 +263,7 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 
 	err := p.storeGitHubUserInfo(userInfo)
 	if err != nil {
-		mlog.Error(err.Error())
+		p.API.LogWarn("Failed to store github user info", "error", err.Error())
 		return "Failed to store settings"
 	}
 

--- a/server/plugin/permalinks.go
+++ b/server/plugin/permalinks.go
@@ -95,7 +95,7 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClie
 		r := replacements[i]
 		// quick bailout if the commit hash is not proper.
 		if _, err := hex.DecodeString(r.permalinkInfo.commit); err != nil {
-			p.API.LogError("bad git commit hash in permalink", "error", err.Error(), "hash", r.permalinkInfo.commit)
+			p.API.LogError("Bad git commit hash in permalink", "error", err.Error(), "hash", r.permalinkInfo.commit)
 			continue
 		}
 
@@ -106,7 +106,7 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClie
 		if config.EnableCodePreview != "privateAndPublic" {
 			repo, _, err := ghClient.Repositories.Get(ctx, r.permalinkInfo.user, r.permalinkInfo.repo)
 			if err != nil {
-				p.API.LogError("error while fetching repository information",
+				p.API.LogError("Error while fetching repository information",
 					"error", err.Error(),
 					"repo", r.permalinkInfo.repo,
 					"user", r.permalinkInfo.user)
@@ -126,17 +126,17 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClie
 		fileContent, _, _, err := ghClient.Repositories.GetContents(ctx,
 			r.permalinkInfo.user, r.permalinkInfo.repo, r.permalinkInfo.path, &opts)
 		if err != nil {
-			p.API.LogError("error while fetching file contents", "error", err.Error(), "path", r.permalinkInfo.path)
+			p.API.LogError("Error while fetching file contents", "error", err.Error(), "path", r.permalinkInfo.path)
 			continue
 		}
 		// this is not a file, ignore.
 		if fileContent == nil {
-			p.API.LogWarn("permalink is not a file", "file", r.permalinkInfo.path)
+			p.API.LogWarn("Permalink is not a file", "file", r.permalinkInfo.path)
 			continue
 		}
 		decoded, err := fileContent.GetContent()
 		if err != nil {
-			p.API.LogError("error while decoding file contents", "error", err.Error(), "path", r.permalinkInfo.path)
+			p.API.LogError("Error while decoding file contents", "error", err.Error(), "path", r.permalinkInfo.path)
 			continue
 		}
 
@@ -153,10 +153,10 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClie
 		}
 		lines, err := filterLines(decoded, start, end)
 		if err != nil {
-			p.API.LogError("error while filtering lines", "error", err.Error(), "path", r.permalinkInfo.path)
+			p.API.LogError("Error while filtering lines", "error", err.Error(), "path", r.permalinkInfo.path)
 		}
 		if lines == "" {
-			p.API.LogError("line numbers out of range. Skipping.", "file", r.permalinkInfo.path, "start", start, "end", end)
+			p.API.LogError("Line numbers out of range. Skipping.", "file", r.permalinkInfo.path, "start", start, "end", end)
 			continue
 		}
 		final := getCodeMarkdown(r.permalinkInfo.user, r.permalinkInfo.repo, r.permalinkInfo.path, r.word, lines, isTruncated)

--- a/server/plugin/permalinks_test.go
+++ b/server/plugin/permalinks_test.go
@@ -412,8 +412,8 @@ func TestMakeReplacements(t *testing.T) {
 		})
 	}
 
-	mockPluginAPI.AssertCalled(t, "LogError", "bad git commit hash in permalink", "error", "encoding/hex: invalid byte: U+0068 'h'", "hash", "badhash")
-	mockPluginAPI.AssertCalled(t, "LogError", "error while fetching file contents", "error", "unmarshalling failed for both file and directory content: unexpected end of JSON input and unexpected end of JSON input", "path", "path/file.go")
+	mockPluginAPI.AssertCalled(t, "LogError", "Bad git commit hash in permalink", "error", "encoding/hex: invalid byte: U+0068 'h'", "hash", "badhash")
+	mockPluginAPI.AssertCalled(t, "LogError", "Error while fetching file contents", "error", "unmarshalling failed for both file and directory content: unexpected end of JSON input and unexpected end of JSON input", "path", "path/file.go")
 }
 
 const (

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v31/github"
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/pkg/errors"
 )
 
@@ -128,7 +127,7 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 	}
 
 	if err != nil {
-		mlog.Error(err.Error())
+		p.API.LogWarn("Failed to get repository or org for subscribe action", "error", err.Error())
 		return errors.Errorf("Encountered an error subscribing to %s", fullNameFromOwnerAndRepo(owner, repo))
 	}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -5,13 +5,11 @@ import (
 	"crypto/hmac"
 	"crypto/sha1" //nolint:gosec // GitHub webhooks are signed using sha1 https://developer.github.com/webhooks/.
 	"encoding/hex"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/google/go-github/v31/github"
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
@@ -82,7 +80,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	event, err := github.ParseWebHook(github.WebHookType(r), body)
 	if err != nil {
-		mlog.Error("GitHub webhook content type should be set to \"application/json\"", mlog.Err(err))
+		p.API.LogDebug("GitHub webhook content type should be set to \"application/json\"", "error", err.Error)
 		http.Error(w, "wrong mime-type. should be \"application/json\"", http.StatusBadRequest)
 		return
 	}
@@ -172,10 +170,11 @@ func (p *Plugin) permissionToRepo(userID string, ownerAndRepo string) bool {
 
 	if result, _, err := githubClient.Repositories.Get(context.Background(), owner, repo); result == nil || err != nil {
 		if err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Failed fetch repository to check permission", "error", err.Error())
 		}
 		return false
 	}
+
 	return true
 }
 
@@ -186,7 +185,7 @@ func (p *Plugin) excludeConfigOrgMember(user *github.User, subscription *Subscri
 
 	info, err := p.getGitHubUserInfo(subscription.CreatorID)
 	if err != nil {
-		mlog.Warn(err.Message)
+		p.API.LogWarn("Failed to exclude org member", "error", err.Message)
 		return false
 	}
 
@@ -218,13 +217,13 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 
 	newPRMessage, err := renderTemplate("newPR", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
 	closedPRMessage, err := renderTemplate("closedPR", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -259,7 +258,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			if label != "" && label == eventLabel {
 				pullRequestLabelledMessage, err := renderTemplate("pullRequestLabelled", event)
 				if err != nil {
-					mlog.Error("failed to render template", mlog.Err(err))
+					p.API.LogWarn("Failed to render template", "error", err.Error())
 					return
 				}
 
@@ -279,7 +278,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -296,7 +295,7 @@ func (p *Plugin) handlePRDescriptionMentionNotification(event *github.PullReques
 
 	message, err := renderTemplate("pullRequestMentionNotification", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -334,7 +333,7 @@ func (p *Plugin) handlePRDescriptionMentionNotification(event *github.PullReques
 		post.ChannelId = channel.Id
 		_, err = p.API.CreatePost(post)
 		if err != nil {
-			mlog.Error("Error creating mention post: " + err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 
 		p.sendRefreshEvent(userID)
@@ -370,7 +369,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 
 	renderedMessage, err := renderTemplate(issueTemplate, event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 	post := &model.Post{
@@ -416,7 +415,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -437,7 +436,7 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 
 	pushedCommitsMessage, err := renderTemplate("pushedCommits", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -458,7 +457,7 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -478,7 +477,7 @@ func (p *Plugin) postCreateEvent(event *github.CreateEvent) {
 
 	newCreateMessage, err := renderTemplate("newCreateMessage", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -499,7 +498,7 @@ func (p *Plugin) postCreateEvent(event *github.CreateEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -521,7 +520,7 @@ func (p *Plugin) postDeleteEvent(event *github.DeleteEvent) {
 
 	newDeleteMessage, err := renderTemplate("newDeleteMessage", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -542,7 +541,7 @@ func (p *Plugin) postDeleteEvent(event *github.DeleteEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -562,7 +561,7 @@ func (p *Plugin) postIssueCommentEvent(event *github.IssueCommentEvent) {
 
 	message, err := renderTemplate("issueComment", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -604,7 +603,7 @@ func (p *Plugin) postIssueCommentEvent(event *github.IssueCommentEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -627,13 +626,13 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 	case "COMMENTED":
 	case "CHANGES_REQUESTED":
 	default:
-		mlog.Warn(fmt.Sprintf("unhandled review state %s", event.GetReview().GetState()))
+		p.API.LogDebug("Unhandled review state", "state", event.GetReview().GetState())
 		return
 	}
 
 	newReviewMessage, err := renderTemplate("pullRequestReviewEvent", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -672,7 +671,7 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -687,7 +686,7 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 
 	newReviewMessage, err := renderTemplate("newReviewComment", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -726,7 +725,7 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 
 		post.ChannelId = sub.ChannelID
 		if _, err := p.API.CreatePost(post); err != nil {
-			mlog.Error(err.Error())
+			p.API.LogWarn("Error webhook post", "error", err.Error())
 		}
 	}
 }
@@ -748,7 +747,7 @@ func (p *Plugin) handleCommentMentionNotification(event *github.IssueCommentEven
 
 	message, err := renderTemplate("commentMentionNotification", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -786,7 +785,7 @@ func (p *Plugin) handleCommentMentionNotification(event *github.IssueCommentEven
 		post.ChannelId = channel.Id
 		_, err = p.API.CreatePost(post)
 		if err != nil {
-			mlog.Error("Error creating mention post: " + err.Error())
+			p.API.LogWarn("Error creating mention post", "error", err.Error())
 		}
 
 		p.sendRefreshEvent(userID)
@@ -825,13 +824,13 @@ func (p *Plugin) handleCommentAuthorNotification(event *github.IssueCommentEvent
 	case "issues":
 		templateName = "commentAuthorIssueNotification"
 	default:
-		mlog.Warn(fmt.Sprintf("unhandled issue type %s", splitURL[len(splitURL)-2]))
+		p.API.LogDebug("Unhandled issue type", "type", splitURL[len(splitURL)-2])
 		return
 	}
 
 	message, err := renderTemplate(templateName, event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -886,13 +885,13 @@ func (p *Plugin) handlePullRequestNotification(event *github.PullRequestEvent) {
 			assigneeUserID = ""
 		}
 	default:
-		mlog.Warn(fmt.Sprintf("unhandled event action %s", event.GetAction()))
+		p.API.LogDebug("Unhandled event action", "action", event.GetAction())
 		return
 	}
 
 	message, err := renderTemplate("pullRequestNotification", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -938,13 +937,13 @@ func (p *Plugin) handleIssueNotification(event *github.IssuesEvent) {
 			assigneeUserID = ""
 		}
 	default:
-		mlog.Warn(fmt.Sprintf("unhandled event action %s", event.GetAction()))
+		p.API.LogDebug("Unhandled event action", "action", event.GetAction())
 		return
 	}
 
 	message, err := renderTemplate("issueNotification", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 
@@ -984,7 +983,7 @@ func (p *Plugin) handlePullRequestReviewNotification(event *github.PullRequestRe
 
 	message, err := renderTemplate("pullRequestReviewNotification", event)
 	if err != nil {
-		mlog.Error("failed to render template", mlog.Err(err))
+		p.API.LogWarn("Failed to render template", "error", err.Error())
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Migrate existing `fmt.Println` and `mlog.X` calls into RPC logging calls. I added come context to the log call when it was easy to do and appropriated. 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/203

