### PR TITLE
Make RHS more theme aware

### DIFF
--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -93,13 +93,13 @@ function GithubItems(props) {
         if (item.status) {
             switch (item.status) {
             case 'success':
-                status = (<div style={{...style.icon, fill: '#2b9643'}}><TickIcon/></div>);
+                status = (<div style={{...style.icon, ...style.iconSucess}}><TickIcon/></div>);
                 break;
             case 'pending':
-                status = (<div style={{...style.icon, fill: '#c59e17'}}><DotIcon/></div>);
+                status = (<div style={{...style.icon, ...style.iconPending}}><DotIcon/></div>);
                 break;
             default:
-                status = (<div style={{...style.icon, fill: '#c11b28'}}><CrossIcon/></div>);
+                status = (<div style={{...style.icon, ...style.iconFailed}}><CrossIcon/></div>);
             }
         }
 
@@ -187,8 +187,20 @@ const getStyle = makeStyleFromTheme((theme) => {
             display: 'inline-flex',
             alignItems: 'center',
         },
+        iconSucess: {
+            fill: theme.onlineIndicator,
+        },
+        iconPending: {
+            fill: theme.awayIndicator,
+        },
+        iconFailed: {
+            fill: theme.dndIndicator,
+        },
+        iconChangesRequested: {
+            fill: theme.dndIndicator,
+        },
         conflictIcon: {
-            color: theme.errorTextColor,
+            color: theme.dndIndicator,
         },
         milestoneIcon: {
             top: 3,
@@ -196,6 +208,7 @@ const getStyle = makeStyleFromTheme((theme) => {
             height: 18,
             display: 'inline-flex',
             alignItems: 'center',
+            fill: theme.centerChannelColor,
         },
     };
 });
@@ -265,7 +278,7 @@ function getReviewText(item, style, secondLine) {
         } else {
             reviewName = 'reviews';
         }
-        reviews = (<span>{approved + ' out of ' + totalReviewers + ' ' + reviewName + ' complete.'}</span>);
+        reviews = (<span className='light'>{approved + ' out of ' + totalReviewers + ' ' + reviewName + ' complete.'}</span>);
     }
 
     if (changesRequested > 0) {
@@ -275,14 +288,13 @@ function getReviewText(item, style, secondLine) {
                 placement='bottom'
                 overlay={<Tooltip id='changesRequestedTooltip'>{'Changes Requested'}</Tooltip>}
             >
-                <div style={{...style.icon, fill: '#c11b28'}}><ChangesRequestedIcon/></div>
+                <div style={{...style.icon, ...style.iconChangesRequested}}><ChangesRequestedIcon/></div>
             </OverlayTrigger>
         );
     }
 
     return (
         <div
-            className='light'
             style={secondLine ? style.subtitleSecondLine : style.subtitle}
         >
             {reviews} {changes}


### PR DESCRIPTION
#### Summary

This PR improves the them awareness of the RHS by using theme defined colors instead of pre defined ones. It also improves the visual appeal by reducing the number of colors used.

The changes are:
- Remove opacity from Milestone icon
- Use theme colors of PR status icons
- Use `dndIndicator` color for merge conflict icon
- Use `dndIndicator` color for changes requested icon

| Before  | After           |
|---------|-----------------|
| ![Screenshot from 2020-09-11 11-15-49](https://user-images.githubusercontent.com/16541325/93178160-20456400-f734-11ea-91e9-87ee5a51c56c.png) | ![Screenshot from 2020-09-11 11-16-40](https://user-images.githubusercontent.com/16541325/93178179-28050880-f734-11ea-815e-9ba1e214845b.png) |
| ![Screenshot from 2020-09-11 11-15-33](https://user-images.githubusercontent.com/16541325/93178221-394e1500-f734-11ea-8805-93ffb74683d2.png) | ![Screenshot from 2020-09-11 11-16-53](https://user-images.githubusercontent.com/16541325/93178261-47039a80-f734-11ea-9785-26bc23a43bd6.png) |

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/270
