### PR TITLE
Only render tooltip on hover

### DIFF
--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -7,10 +7,10 @@ import ReactMarkdown from 'react-markdown';
 import Client from 'client';
 import {getLabelFontColor, hexToRGB} from '../../utils/styles';
 
-export const LinkTooltip = ({href, connected, theme}) => {
+export const LinkTooltip = ({href, connected, show, theme}) => {
     const [data, setData] = useState(null);
     useEffect(() => {
-        const init = async () => {
+        const initData = async () => {
             if (href.includes('github.com/')) {
                 const [owner, repo, type, number] = href.split('github.com/')[1].split('/');
                 let res;
@@ -30,13 +30,14 @@ export const LinkTooltip = ({href, connected, theme}) => {
                 setData(res);
             }
         };
-        if (data) {
+
+        // show is not provided for Mattermost Server < 5.28
+        if (!connected || data || ((typeof (show) !== 'undefined' || show != null) && !show)) {
             return;
         }
-        if (connected) {
-            init();
-        }
-    }, []);
+
+        initData();
+    }, [connected, data, href, show]);
 
     const getIconElement = () => {
         let icon;
@@ -174,4 +175,5 @@ LinkTooltip.propTypes = {
     href: PropTypes.string.isRequired,
     connected: PropTypes.bool.isRequired,
     theme: PropTypes.object.isRequired,
+    show: PropTypes.bool,
 };


### PR DESCRIPTION
#### Summary
Make use of the `show` prop added in https://github.com/mattermost/mattermost-webapp/pull/6492 by only rendering the tooltip on hover. This means data is not longer pre-fetched. Therefore a small delay is visible when hovering. Please note, on re-hovering the link the tooltip is shown imminently. Switching channel caused the data to be lost and it's required to fetch is again. I opted for this approach because storing the data in redux would mean that we would have to clean it up from time to time and it's hard to figure out what data should be cleaned up.

The change is backward compatible to 

I did also simplify the existing code a bit.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28591
