### PR TITLE
Don't try to fetch PR/issue details for malformed link

### DIFF
--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -13,6 +13,10 @@ export const LinkTooltip = ({href, connected, theme}) => {
         const init = async () => {
             if (href.includes('github.com/')) {
                 const [owner, repo, type, number] = href.split('github.com/')[1].split('/');
+                if (!owner | !repo | !type | !number) {
+                    return;
+                }
+
                 let res;
                 switch (type) {
                 case 'issues':


### PR DESCRIPTION
#### Summary
For links like https://github.com/mattermost/mattermost-plugin-agenda/pull the tooltip should not try to fetch the PR/issue details.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28543
