### PR TITLE
Fix issue labeling double message

### DIFF
--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -347,7 +347,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 	action := event.GetAction()
 
 	// This condition is made to check if the message doesn't get automatically labeled to prevent duplicated issue messages
-	timeDiff := issue.GetCreatedAt().Sub(time.Now())
+	timeDiff := time.Until(issue.GetCreatedAt()) * -1
 	if action == "labeled" && timeDiff.Seconds() < 4.00 {
 		return
 	}

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -346,7 +346,9 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 	issue := event.GetIssue()
 	action := event.GetAction()
 
-	if time.Now().Unix()-issue.GetCreatedAt().Unix() <= 3 && action == "labeled" {
+	// This condition is made to check if the message doesn't get automatically labeled to prevent duplicated issue messages
+	timeDiff := issue.GetCreatedAt().Sub(time.Now())
+	if action == "labeled" && timeDiff.Seconds() < 4.00 {
 		return
 	}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -346,7 +346,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 	issue := event.GetIssue()
 	action := event.GetAction()
 
-	if issue.GetCreatedAt().Unix()-time.Now().Unix() <= 3 && action == "labeled" {
+	if time.Now().Unix()-issue.GetCreatedAt().Unix() <= 3 && action == "labeled" {
 		return
 	}
 


### PR DESCRIPTION
#### Summary
This PR fixed double messaging when an issue gets labeled in the process of creating it

#### Ticket Link
This PR is linked with the issue #389 

