### PR TITLE
Subscription using --exclude-org-member flag should fail without locked org

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -567,6 +567,13 @@ func (p *Plugin) isUserOrganizationMember(githubClient *github.Client, user *git
 	return isMember
 }
 
+func (p *Plugin) isOrganizationLocked() bool {
+	config := p.getConfiguration()
+	configOrg := strings.TrimSpace(config.GitHubOrg)
+
+	return configOrg != ""
+}
+
 func (p *Plugin) sendRefreshEvent(userID string) {
 	p.API.PublishWebSocketEvent(
 		wsEventRefresh,

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -105,6 +105,10 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		return errors.Wrap(err, "organization not supported")
 	}
 
+	if flags.ExcludeOrgMembers && !p.isOrganizationLocked() {
+		return errors.Errorf("Unable to set --exclude-org-member flag. The GitHub plugin is not locked to a single organization.")
+	}
+
 	var err error
 
 	if repo == "" {


### PR DESCRIPTION
#### Summary
The pull request adds a check to fail github subscription when flag `--exclude-org-member` is set, but organization is not locked.

For testing, I created a new org and a repo inside that org and tried subscribing to it with/without flag. 

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-github/issues/214

