### PR TITLE
[FIX] Handle Issue Creation failures in the correct place

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -1276,6 +1276,10 @@ func (p *Plugin) createIssue(w http.ResponseWriter, r *http.Request, userID stri
 	result, resp, err := githubClient.Issues.Create(context.Background(), owner, repoName, ghIssue)
 	if err != nil {
 		p.API.LogWarn("Failed to create issue", "error", err.Error())
+		if resp != nil && resp.Response.StatusCode == http.StatusGone {
+			p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Issues are disabled on this repository.", StatusCode: http.StatusMethodNotAllowed})
+			return
+		}
 		p.writeAPIError(w,
 			&APIErrorResponse{
 				ID: "",
@@ -1285,11 +1289,6 @@ func (p *Plugin) createIssue(w http.ResponseWriter, r *http.Request, userID stri
 				),
 				StatusCode: resp.StatusCode,
 			})
-		return
-	}
-
-	if resp.Response.StatusCode == http.StatusGone {
-		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "Issues are disabled on this repository.", StatusCode: http.StatusMethodNotAllowed})
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Originally the handler for 410 Gone (Issues not enabled on a repository) was placed after the generic error handling code, meaning it would never be called.



