### PR TITLE
MM-31348 Clarify Mattermost GitHub Plugin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A GitHub plugin for Mattermost. Supports GitHub SaaS and Enterprise versions.
 
 ## Audience
 
-This guide is intended for Mattermost System Admins setting up the GitHub plugin and Mattermost users who want information about the plugin functionality. For more information about contributing to this plugin, visit the [Development section](#development).
+This guide is intended for Mattermost System Admins setting up the GitHub plugin, Mattermost users who want information about the plugin functionality, and Mattermost users who want to connect their GitHub account to Mattermost. For more information about contributing to this plugin, visit the [Development section](#development).
 
 ## License
 
@@ -35,9 +35,9 @@ This repository is licensed under the [Apache 2.0 License](https://github.com/ma
 
 ## About the GitHub Plugin
 
-The Mattermost GitHub plugin uses a webhook to connect your GitHub account to Mattermost to listen for incoming GitHub events. Events notifications are via DM in Mattermost. The Events don’t need separate configuration and include: 
+The Mattermost GitHub plugin uses a webhook to connect your GitHub account to Mattermost to listen for incoming GitHub events. Events notifications are via DM in Mattermost. The Events don’t need separate configuration. 
 
-After your System Admin has [configured the GitHub plugin](#configuration), run `/github connect` in a Mattermost channel to connect your Mattermost and GitHub accounts.
+After a System Admin has configured the GitHub plugin, run `/github connect` in a Mattermost channel to connect your Mattermost and GitHub accounts.
 
 Once connected, you'll have access to the following features:
 
@@ -57,25 +57,31 @@ This guide assumes:
 
 ## Configuration
 
-Configuration is started in GitHub and completed in Mattermost. 
+GitHub plugin configuration starts by registering an OAuth app in GitHub and ends in Mattermost. 
 
 **Note:** If you're using GitHub Enterprise, replace all GitHub links below with your GitHub Enterprise URL.
 
 ### Step 1: Register an OAuth Application in GitHub
 
+You must first register the Mattermost GitHub Plugin as an authorized OAuth app regardless of whether you're setting up the GitHub plugin as a system admin or a Mattermost user.
+
 1. Go to https://github.com/settings/applications/new to register an OAuth app.
 2. Set the following values:
-   - **Application Name:** `Mattermost GitHub Plugin - <your company name>`
+   - **Application name:** `Mattermost GitHub Plugin - <your company name>`
    - **Homepage URL:** `https://github.com/mattermost/mattermost-plugin-github`
-   - **Authorization callback URL:** `https://your-mattermost-url.com/plugins/github/oauth/complete`, replacing `https://your-mattermost-url.com` with your Mattermost URL.
+   - **Authorization callback URL:** `https://your-mattermost-url.com/plugins/github/oauth/complete`, replacing `https://your-mattermost-url.com` with your Mattermost URL. This value needs to match the Mattermost server URL that you or your users users log in to. 
 3. Submit.
-4. Copy the **Client ID** and **Client Secret** in the resulting screen.
-5. Go to **System Console > Plugins > GitHub** and enter the **GitHub OAuth Client ID** and **GitHub OAuth Client Secret** you copied in a previous step.
-6. Hit **Save**.
+4. Click **Generate a new client secret** and provide your GitHub password to continue.
+5. Copy the **Client ID** and **Client Secret** in the resulting screen.
+6. Once you have successfully registered the Mattermost GitHub Plugin as an authorized OAuth app, switch to Mattermost and run `/github connect` in a Mattermost channel. You should receive a DM from the GitHub plugin about the features you have available.
+
+A system admin performs the remaining steps using the System Console:
+7. Go to **System Console > Plugins > GitHub** and enter the **GitHub OAuth Client ID** and **GitHub OAuth Client Secret** you copied in a previous step.
+8. Hit **Save**.
 
 ### Step 2: Create a Webhook in GitHub
 
-You must create a webhook for each organization you want to receive notifications for or subscribe to.
+As a system admin, you must create a webhook for each organization you want to receive notifications for or subscribe to.
 
 1. In **System Console > Plugins > GitHub**, generate a new value for **Webhook Secret**. Copy it, as you will use it in a later step.
 2. Hit **Save** to save the secret.
@@ -93,7 +99,7 @@ If you have multiple organizations, repeat the process starting from step 3 to c
 
 ### Step 3: Configure the Plugin in Mattermost
 
-If you have an existing Mattermost user account with the name `github`, the plugin will post using the `github` account but without a `BOT` tag.
+As a system admin, if you have an existing Mattermost user account with the name `github`, the plugin will post using the `github` account but without a `BOT` tag.
 
 To prevent this, either:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You must first register the Mattermost GitHub Plugin as an authorized OAuth app 
 5. Copy the **Client ID** and **Client Secret** in the resulting screen.
 6. Once you have successfully registered the Mattermost GitHub Plugin as an authorized OAuth app, switch to Mattermost and run `/github connect` in a Mattermost channel. You should receive a DM from the GitHub plugin about the features you have available.
 
-A system admin performs the remaining steps using the System Console:
+A System Admin performs the remaining steps:
 7. Go to **System Console > Plugins > GitHub** and enter the **GitHub OAuth Client ID** and **GitHub OAuth Client Secret** you copied in a previous step.
 8. Hit **Save**.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you have multiple organizations, repeat the process starting from step 3 to c
 
 ### Step 3: Configure the Plugin in Mattermost
 
-As a system admin, if you have an existing Mattermost user account with the name `github`, the plugin will post using the `github` account but without a `BOT` tag.
+As a System Admin, if you have an existing Mattermost user account with the name `github`, the plugin will post using the `github` account but without a `BOT` tag.
 
 To prevent this, either:
 


### PR DESCRIPTION
Documentation for:
- https://mattermost.atlassian.net/browse/MM-31348

Updated:
- Audience section to include MM staff as a key audience for this page
- Updated Configuration > Step 1 to clarify steps for MM users
- Updated Configuration > Step 2 & Step 3 to clarify steps completed by system admins