### PR TITLE
Made GitHub username clickable

### DIFF
--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -160,7 +160,7 @@ function GithubItems(props) {
                     style={style.subtitle}
                 >
                     {item.created_at && ('Opened ' + formatTimeSince(item.created_at) + ' ago')}
-                    {userName && <a href={userProfile}>' by ' {userName}</a>}
+                    {userName && <a href={userProfile}> by {userName}</a>}
                     {(item.created_at || userName) && '.'}
                     {milestone}
                     {item.reason ? (<React.Fragment>

--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -24,11 +24,9 @@ function GithubItems(props) {
         const repoName = item.repository_url ? item.repository_url.replace(/.+\/repos\//, '') : item.repository.full_name;
 
         let userName = null;
-        let userProfile = null;
 
         if (item.user) {
             userName = item.user.login;
-            userProfile = `https://github.com/${userName}`;
         } else if (item.owner) {
             userName = item.owner.login;
         }
@@ -160,7 +158,14 @@ function GithubItems(props) {
                     style={style.subtitle}
                 >
                     {item.created_at && ('Opened ' + formatTimeSince(item.created_at) + ' ago')}
-                    {userName && <a href={userProfile}> by {userName}</a>}
+                    {userName && (
+                        <>
+                            {' by '}
+                            <a href={`https://github.com/${userName}`}>
+                                {userName}
+                            </a>
+                        </>
+                    )}
                     {(item.created_at || userName) && '.'}
                     {milestone}
                     {item.reason ? (<React.Fragment>

--- a/webapp/src/components/sidebar_right/github_items.jsx
+++ b/webapp/src/components/sidebar_right/github_items.jsx
@@ -24,9 +24,11 @@ function GithubItems(props) {
         const repoName = item.repository_url ? item.repository_url.replace(/.+\/repos\//, '') : item.repository.full_name;
 
         let userName = null;
+        let userProfile = null;
 
         if (item.user) {
             userName = item.user.login;
+            userProfile = `https://github.com/${userName}`;
         } else if (item.owner) {
             userName = item.owner.login;
         }
@@ -158,7 +160,7 @@ function GithubItems(props) {
                     style={style.subtitle}
                 >
                     {item.created_at && ('Opened ' + formatTimeSince(item.created_at) + ' ago')}
-                    {userName && ' by ' + userName}
+                    {userName && <a href={userProfile}>' by ' {userName}</a>}
                     {(item.created_at || userName) && '.'}
                     {milestone}
                     {item.reason ? (<React.Fragment>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
* Added the userProfile variable to hold the user's GitHub profile URL.
* Wrapped the userName variable in `<a></a>` with a link to the URL provided from the userProfile variable.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/408