### PR TITLE
mm-182 - adds a {time} ago field in the list of unread messages pane. 

### DIFF
--- a/webapp/src/components/sidebar_right/github_items.tsx
+++ b/webapp/src/components/sidebar_right/github_items.tsx
@@ -55,6 +55,7 @@ interface Item {
     id: number;
     title: string;
     created_at: string;
+    updated_at: string;
     html_url: string;
     repository_url?: string;
     user: User;
@@ -244,6 +245,7 @@ function GithubItems(props: GithubItemsProps) {
                     {milestone}
                     {item.reason ? (<>
                         {(item.created_at || userName || milestone) && (<br/>)}
+                        {item.updated_at && (formatTimeSince(item.updated_at) + ' ago')}{<br/>}
                         {notificationReasons[item.reason]}
                     </>) : null }
                 </div>


### PR DESCRIPTION
#### Summary
Adds the following time field in the list of unread messages in the RHS
![image](https://user-images.githubusercontent.com/85172229/127094257-789e1e38-ebc9-4157-af0e-824010311a7c.png)

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-github/issues/182
