### PR TITLE
Fix cutoff words in word wrap

### DIFF
--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -66,13 +66,12 @@
 }
 
 .github-tooltip .tooltip-info .markdown-text {
-    -webkit-hyphens: auto;
-    -ms-hyphens: auto;
-    hyphens: auto;
     max-height: 150px;
     line-height: 1.25;
     overflow: hidden;
-    word-break: break-all;
+    word-break: break-word;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
     font-size: 12px;
 }
 


### PR DESCRIPTION
#### Summary

Updates css to fix cutoff words in word wrap.

#### Ticket Link

Fixes: #455 