### PR TITLE
mm-461 Trailing space in my access_token causes uninformative error message fixes #461

### DIFF
--- a/server/client/client.go
+++ b/server/client/client.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/google/go-github/v31/github"
 	"github.com/pkg/errors"
@@ -83,13 +84,18 @@ func (c *Client) GetConfiguration() (*plugin.Configuration, error) {
 
 	config := &plugin.Configuration{}
 	err = json.Unmarshal(respBody, config)
+	config.GitHubOrg = TrimSpace(config.GitHubOrg)
+	config.GitHubOAuthClientID = TrimSpace(config.GitHubOAuthClientID)
+	config.GitHubOAuthClientSecret = TrimSpace(config.GitHubOAuthClientSecret)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode GitHub config")
 	}
 
 	return config, nil
 }
-
+func TrimSpace(value string){
+	return strings.TrimSpace(value)
+}
 func (c *Client) GetToken(userID string) (*oauth2.Token, error) {
 	req, err := http.NewRequest(http.MethodGet, "/"+plugin.Manifest.Id+"/api/v1/token", http.NoBody)
 	if err != nil {

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -84,18 +84,16 @@ func (c *Client) GetConfiguration() (*plugin.Configuration, error) {
 
 	config := &plugin.Configuration{}
 	err = json.Unmarshal(respBody, config)
-	config.GitHubOrg = TrimSpace(config.GitHubOrg)
-	config.GitHubOAuthClientID = TrimSpace(config.GitHubOAuthClientID)
-	config.GitHubOAuthClientSecret = TrimSpace(config.GitHubOAuthClientSecret)
+	config.GitHubOrg = strings.TrimSpace(config.GitHubOrg)
+	config.GitHubOAuthClientID = strings.TrimSpace(config.GitHubOAuthClientID)
+	config.GitHubOAuthClientSecret = strings.TrimSpace(config.GitHubOAuthClientSecret)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decode GitHub config")
 	}
 
 	return config, nil
 }
-func TrimSpace(value string) string {
-	return strings.TrimSpace(value)
-}
+
 func (c *Client) GetToken(userID string) (*oauth2.Token, error) {
 	req, err := http.NewRequest(http.MethodGet, "/"+plugin.Manifest.Id+"/api/v1/token", http.NoBody)
 	if err != nil {

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -93,7 +93,7 @@ func (c *Client) GetConfiguration() (*plugin.Configuration, error) {
 
 	return config, nil
 }
-func TrimSpace(value string){
+func TrimSpace(value string) string {
 	return strings.TrimSpace(value)
 }
 func (c *Client) GetToken(userID string) (*oauth2.Token, error) {

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -65,8 +66,13 @@ func (p *Plugin) getConfiguration() *Configuration {
 	if p.configuration == nil {
 		return &Configuration{}
 	}
-
+	p.configuration.GitHubOrg = TrimSpace(p.configuration.GitHubOrg)
+	p.configuration.GitHubOAuthClientID = TrimSpace(p.configuration.GitHubOAuthClientID)
+	p.configuration.GitHubOAuthClientSecret = TrimSpace(p.configuration.GitHubOAuthClientSecret)
 	return p.configuration
+}
+func TrimSpace(value string) string {
+	return strings.TrimSpace(value)
 }
 
 // setConfiguration replaces the active configuration under lock.

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -66,13 +66,10 @@ func (p *Plugin) getConfiguration() *Configuration {
 	if p.configuration == nil {
 		return &Configuration{}
 	}
-	p.configuration.GitHubOrg = TrimSpace(p.configuration.GitHubOrg)
-	p.configuration.GitHubOAuthClientID = TrimSpace(p.configuration.GitHubOAuthClientID)
-	p.configuration.GitHubOAuthClientSecret = TrimSpace(p.configuration.GitHubOAuthClientSecret)
+	p.configuration.GitHubOrg = strings.TrimSpace(p.configuration.GitHubOrg)
+	p.configuration.GitHubOAuthClientID = strings.TrimSpace(p.configuration.GitHubOAuthClientID)
+	p.configuration.GitHubOAuthClientSecret = strings.TrimSpace(p.configuration.GitHubOAuthClientSecret)
 	return p.configuration
-}
-func TrimSpace(value string) string {
-	return strings.TrimSpace(value)
 }
 
 // setConfiguration replaces the active configuration under lock.


### PR DESCRIPTION
Removed trailing spaces from clientid , accesstoken and orgname while geting the configuration

ticket here
https://github.com/mattermost/mattermost-plugin-github/issues/461