### PR TITLE
MM-34646: force-refresh user tokens

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -348,7 +348,7 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 		return
 	}
 
-	githubClient := p.githubConnect(*tok)
+	githubClient := p.githubConnectToken(*tok)
 	gitUser, _, err := githubClient.Users.Get(ctx, "")
 	if err != nil {
 		p.API.LogWarn("Failed to get authenticated GitHub user", "error", err.Error())
@@ -441,22 +441,6 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-}
-
-func (p *Plugin) refreshAccessToken(c *UserContext) (*oauth2.Token, error) {
-	conf := p.getOAuthConfig(c.GHInfo.AllowedPrivateRepos)
-
-	ts := conf.TokenSource(c.Ctx, c.GHInfo.Token)
-	newToken, err := ts.Token()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to obtain refreshed token")
-	}
-
-	fmt.Printf("<>/<> Access: %v %q %q,  Refresh: %v %q %q\n",
-		newToken.AccessToken == c.GHInfo.Token.AccessToken, newToken.AccessToken, c.GHInfo.Token.AccessToken,
-		newToken.RefreshToken == c.GHInfo.Token.RefreshToken, newToken.RefreshToken, c.GHInfo.Token.RefreshToken)
-
-	return newToken, nil
 }
 
 func (p *Plugin) getGitHubUser(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -594,7 +578,7 @@ func (p *Plugin) getSettings(w http.ResponseWriter, _ *http.Request) {
 func (p *Plugin) getMentions(c *UserContext, w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	username := c.GHInfo.GitHubUsername
 	query := getMentionSearchQuery(username, config.GitHubOrg)
 
@@ -608,7 +592,7 @@ func (p *Plugin) getMentions(c *UserContext, w http.ResponseWriter, r *http.Requ
 }
 
 func (p *Plugin) getUnreads(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	notifications, _, err := githubClient.Activity.ListNotifications(c.Ctx, &github.NotificationListOptions{})
 	if err != nil {
@@ -652,7 +636,7 @@ func (p *Plugin) getUnreads(c *UserContext, w http.ResponseWriter, r *http.Reque
 func (p *Plugin) getReviews(c *UserContext, w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	username := c.GHInfo.GitHubUsername
 
 	query := getReviewSearchQuery(username, config.GitHubOrg)
@@ -668,7 +652,7 @@ func (p *Plugin) getReviews(c *UserContext, w http.ResponseWriter, r *http.Reque
 func (p *Plugin) getYourPrs(c *UserContext, w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	username := c.GHInfo.GitHubUsername
 
 	query := getYourPrsSearchQuery(username, config.GitHubOrg)
@@ -682,7 +666,7 @@ func (p *Plugin) getYourPrs(c *UserContext, w http.ResponseWriter, r *http.Reque
 }
 
 func (p *Plugin) getPrsDetails(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	var prList []*PRDetails
 	if err := json.NewDecoder(r.Body).Decode(&prList); err != nil {
@@ -784,7 +768,7 @@ func getRepoOwnerAndNameFromURL(url string) (string, string) {
 func (p *Plugin) searchIssues(c *UserContext, w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	searchTerm := r.FormValue("term")
 	query := getIssuesSearchQuery(config.GitHubOrg, searchTerm)
@@ -863,7 +847,7 @@ func (p *Plugin) createIssueComment(c *UserContext, w http.ResponseWriter, r *ht
 		return
 	}
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	post, appErr := p.API.GetPost(req.PostID)
 	if appErr != nil {
@@ -927,7 +911,7 @@ func (p *Plugin) createIssueComment(c *UserContext, w http.ResponseWriter, r *ht
 func (p *Plugin) getYourAssignments(c *UserContext, w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	username := c.GHInfo.GitHubUsername
 	query := getYourAssigneeSearchQuery(username, config.GitHubOrg)
@@ -941,7 +925,7 @@ func (p *Plugin) getYourAssignments(c *UserContext, w http.ResponseWriter, r *ht
 }
 
 func (p *Plugin) postToDo(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	username := c.GHInfo.GitHubUsername
 
 	text, err := p.GetToDo(c.Ctx, username, githubClient)
@@ -995,7 +979,7 @@ func (p *Plugin) getIssueByNumber(c *UserContext, w http.ResponseWriter, r *http
 		return
 	}
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	result, _, err := githubClient.Issues.Get(c.Ctx, owner, repo, numberInt)
 	if err != nil {
@@ -1029,7 +1013,7 @@ func (p *Plugin) getPrByNumber(c *UserContext, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	result, _, err := githubClient.PullRequests.Get(c.Ctx, owner, repo, numberInt)
 	if err != nil {
@@ -1064,7 +1048,7 @@ func (p *Plugin) getLabels(c *UserContext, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	var allLabels []*github.Label
 	opt := github.ListOptions{PerPage: 50}
 
@@ -1092,7 +1076,7 @@ func (p *Plugin) getAssignees(c *UserContext, w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	var allAssignees []*github.User
 	opt := github.ListOptions{PerPage: 50}
 
@@ -1120,7 +1104,7 @@ func (p *Plugin) getMilestones(c *UserContext, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	var allMilestones []*github.Milestone
 	opt := github.ListOptions{PerPage: 50}
 
@@ -1142,7 +1126,7 @@ func (p *Plugin) getMilestones(c *UserContext, w http.ResponseWriter, r *http.Re
 }
 
 func (p *Plugin) getRepositories(c *UserContext, w http.ResponseWriter, r *http.Request) {
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 
 	org := p.getConfiguration().GitHubOrg
 
@@ -1285,7 +1269,7 @@ func (p *Plugin) createIssue(c *UserContext, w http.ResponseWriter, r *http.Requ
 	owner := splittedRepo[0]
 	repoName := splittedRepo[1]
 
-	githubClient := p.githubConnect(*c.GHInfo.Token)
+	githubClient := p.githubConnectUser(c.Context.Ctx, c.GHInfo)
 	result, resp, err := githubClient.Issues.Create(c.Ctx, owner, repoName, ghIssue)
 	if err != nil {
 		if resp != nil && resp.Response.StatusCode == http.StatusGone {

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -443,6 +443,22 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 	}
 }
 
+func (p *Plugin) refreshAccessToken(c *UserContext) (*oauth2.Token, error) {
+	conf := p.getOAuthConfig(c.GHInfo.AllowedPrivateRepos)
+
+	ts := conf.TokenSource(c.Ctx, c.GHInfo.Token)
+	newToken, err := ts.Token()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to obtain refreshed token")
+	}
+
+	fmt.Printf("<>/<> Access: %v %q %q,  Refresh: %v %q %q\n",
+		newToken.AccessToken == c.GHInfo.Token.AccessToken, newToken.AccessToken, c.GHInfo.Token.AccessToken,
+		newToken.RefreshToken == c.GHInfo.Token.RefreshToken, newToken.RefreshToken, c.GHInfo.Token.RefreshToken)
+
+	return newToken, nil
+}
+
 func (p *Plugin) getGitHubUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	type GitHubUserRequest struct {
 		UserID string `json:"user_id"`

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -366,7 +366,8 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 			DailyReminder:  true,
 			Notifications:  true,
 		},
-		AllowedPrivateRepos: state.PrivateAllowed,
+		AllowedPrivateRepos:   state.PrivateAllowed,
+		MM34646ResetTokenDone: true,
 	}
 
 	if err = p.storeGitHubUserInfo(userInfo); err != nil {

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -446,25 +446,6 @@ func (p *Plugin) handleSettings(_ *plugin.Context, _ *model.CommandArgs, paramet
 	return "Settings updated."
 }
 
-func (p *Plugin) handleTest(_ *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string {
-	info, apiErr := p.getGitHubUserInfo(args.UserId)
-	if apiErr != nil {
-		return "failed to get GitHubUserInfo, error: " + apiErr.Error()
-	}
-
-	_, err := p.forceResetUserTokenMM34646(context.Background(), p.getConfiguration(), *info)
-	if err != nil {
-		return "forceResetUserToken error: " + err.Error()
-	}
-
-	err = p.forceResetAllMM34646()
-	if err != nil {
-		return "forceResetAll error: " + err.Error()
-	}
-
-	return "OK"
-}
-
 func (p *Plugin) handleIssue(_ *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string {
 	if len(parameters) == 0 {
 		return "Invalid issue command. Available command is 'create'."

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -470,7 +470,38 @@ func (p *Plugin) handleIssue(_ *plugin.Context, args *model.CommandArgs, paramet
 
 type CommandHandleFunc func(c *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string
 
+func (p *Plugin) isAuthorizedSysAdmin(userID string) (bool, error) {
+	user, appErr := p.API.GetUser(userID)
+	if appErr != nil {
+		return false, appErr
+	}
+	if !strings.Contains(user.Roles, "system_admin") {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	config := p.getConfiguration()
+
+	if err := config.IsValid(); err != nil {
+		isSysAdmin, err := p.isAuthorizedSysAdmin(args.UserId)
+		var text string
+		switch {
+		case err != nil:
+			text = "Error checking user's permissions"
+			p.API.LogWarn(text, "err", err.Error())
+		case isSysAdmin:
+			githubPluginURL := *p.API.GetConfig().ServiceSettings.SiteURL + "/admin_console/plugins/plugin_github"
+			text = fmt.Sprintf("Before using this plugin, you will need to configure it by filling out the settings in the system console [here](%s). You can learn more about the setup process [here](%s).", githubPluginURL, "https://github.com/mattermost/mattermost-plugin-github#step-3-configure-the-plugin-in-mattermost")
+		default:
+			text = "Please contact your system administrator to configure the GitHub plugin."
+		}
+
+		p.postCommandResponse(args, text)
+		return &model.CommandResponse{}, nil
+	}
+
 	command, action, parameters := parseCommand(args.Command)
 
 	if command != "/github" {

--- a/server/plugin/mm_34646_token_refresh.go
+++ b/server/plugin/mm_34646_token_refresh.go
@@ -10,11 +10,14 @@ import (
 )
 
 const pageSize = 100
-const delayBetweenPages = 5 * time.Minute
+const delayBetweenUsers = 1 * time.Second
+const delayToStart = 5 * time.Minute
 
 func (p *Plugin) forceResetAllMM34646() error {
 	config := p.getConfiguration()
 	ctx := context.Background()
+
+	time.Sleep(delayToStart)
 
 	for page := 0; ; page++ {
 		keys, appErr := p.API.KVList(page, pageSize)
@@ -35,6 +38,9 @@ func (p *Plugin) forceResetAllMM34646() error {
 				// too noisy to report
 				continue
 			}
+			if tryInfo.MM34646ResetTokenDone {
+				continue
+			}
 			if tryInfo.Token == nil || tryInfo.Token.AccessToken == "" {
 				// too noisy to report
 				continue
@@ -53,12 +59,13 @@ func (p *Plugin) forceResetAllMM34646() error {
 					"error", err.Error())
 				continue
 			}
+
+			time.Sleep(delayBetweenUsers)
 		}
 
 		if len(keys) < pageSize {
 			break
 		}
-		time.Sleep(delayBetweenPages)
 	}
 	return nil
 }

--- a/server/plugin/mm_34646_token_refresh.go
+++ b/server/plugin/mm_34646_token_refresh.go
@@ -33,12 +33,11 @@ func (p *Plugin) forceResetAllMM34646() error {
 			tryInfo := GitHubUserInfo{}
 			err := json.Unmarshal(data, &tryInfo)
 			if err != nil {
-				p.API.LogDebug("key failed to unmarshal as GitHubUserInfo", "key", key,
-					"error", err.Error())
+				// too noisy to report
 				continue
 			}
 			if tryInfo.Token == nil || tryInfo.Token.AccessToken == "" {
-				p.API.LogDebug("skipping key with no token", "key", key)
+				// too noisy to report
 				continue
 			}
 
@@ -66,7 +65,7 @@ func (p *Plugin) forceResetAllMM34646() error {
 }
 
 func (p *Plugin) forceResetUserTokenMM34646(ctx context.Context, config *Configuration, info GitHubUserInfo) (string, error) {
-	if info.ForceResetTokenMM34646 {
+	if info.MM34646ResetTokenDone {
 		return info.Token.AccessToken, nil
 	}
 
@@ -96,7 +95,7 @@ func (p *Plugin) forceResetUserTokenMM34646(ctx context.Context, config *Configu
 	}
 
 	info.Token.AccessToken = newToken
-	info.ForceResetTokenMM34646 = true
+	info.MM34646ResetTokenDone = true
 	err = p.storeGitHubUserInfo(&info)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to store updated GitHubUserInfo")

--- a/server/plugin/mm_34646_token_refresh.go
+++ b/server/plugin/mm_34646_token_refresh.go
@@ -70,7 +70,7 @@ func (p *Plugin) forceResetUserTokenMM34646(ctx context.Context, config *Configu
 
 	client, err := p.getResetUserTokenMM34646Client(config)
 	if err != nil {
-		p.API.LogInfo("Failed to create a special GitHub client to refresh the user's token", "error", err.Error())
+		return "", errors.Wrap(err, "failed to create a special GitHub client to refresh the user's token")
 	}
 
 	a, _, err := client.Authorizations.Reset(ctx, config.GitHubOAuthClientID, info.Token.AccessToken)

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -84,6 +84,20 @@ func NewPlugin() *Plugin {
 	return p
 }
 
+func (p *Plugin) githubConnectUser(c *UserContext) *github.Client {
+	token := *c.GHInfo.Token
+	if c.GHInfo.ForceRefreshTokenMM34646 {
+		refreshedToken, err := p.refreshAccessToken(c)
+		if err == nil {
+			token = *refreshedToken
+		} else {
+			p.API.LogInfo("Failed to refresh access token", "error", err.Error())
+		}
+	}
+
+	return p.githubConnect(token)
+}
+
 func (p *Plugin) githubConnect(token oauth2.Token) *github.Client {
 	config := p.getConfiguration()
 
@@ -227,6 +241,9 @@ type GitHubUserInfo struct {
 	LastToDoPostAt      int64
 	Settings            *UserSettings
 	AllowedPrivateRepos bool
+
+	// All tokens issued prior to MM-34646 must be refreshed.
+	ForceRefreshTokenMM34646 bool
 }
 
 type UserSettings struct {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -119,12 +119,6 @@ func GetGitHubClient(token oauth2.Token, config *Configuration) (*github.Client,
 }
 
 func (p *Plugin) OnActivate() error {
-	config := p.getConfiguration()
-
-	if err := config.IsValid(); err != nil {
-		return errors.Wrap(err, "invalid config")
-	}
-
 	if p.API.GetConfig().ServiceSettings.SiteURL == nil {
 		return errors.New("siteURL is not set. Please set a siteURL and restart the plugin")
 	}

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -79,7 +79,6 @@ func NewPlugin() *Plugin {
 		"":              p.handleHelp,
 		"settings":      p.handleSettings,
 		"issue":         p.handleIssue,
-		"test":          p.handleTest,
 	}
 
 	return p
@@ -172,6 +171,12 @@ func (p *Plugin) OnActivate() error {
 
 	registerGitHubToUsernameMappingCallback(p.getGitHubToUsernameMapping)
 
+	go func() {
+		err := p.forceResetAllMM34646()
+		if err != nil {
+			p.API.LogDebug("failed to reset user tokens", "error", err.Error())
+		}
+	}()
 	return nil
 }
 
@@ -248,8 +253,8 @@ type GitHubUserInfo struct {
 	Settings            *UserSettings
 	AllowedPrivateRepos bool
 
-	// ForceResetTokenMM34646 is set for a user whose token has been reset for MM-34646.
-	ForceResetTokenMM34646 bool
+	// MM34646ResetTokenDone is set for a user whose token has been reset for MM-34646.
+	MM34646ResetTokenDone bool
 }
 
 type UserSettings struct {

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -167,9 +167,10 @@ func (p *Plugin) permissionToRepo(userID string, ownerAndRepo string) bool {
 	if apiErr != nil {
 		return false
 	}
-	githubClient := p.githubConnect(*info.Token)
+	ctx := context.Background()
+	githubClient := p.githubConnectUser(ctx, info)
 
-	if result, _, err := githubClient.Repositories.Get(context.Background(), owner, repo); result == nil || err != nil {
+	if result, _, err := githubClient.Repositories.Get(ctx, owner, repo); result == nil || err != nil {
 		if err != nil {
 			p.API.LogWarn("Failed fetch repository to check permission", "error", err.Error())
 		}
@@ -190,7 +191,7 @@ func (p *Plugin) excludeConfigOrgMember(user *github.User, subscription *Subscri
 		return false
 	}
 
-	githubClient := p.githubConnect(*info.Token)
+	githubClient := p.githubConnectUser(context.Background(), info)
 	organization := p.getConfiguration().GitHubOrg
 
 	return p.isUserOrganizationMember(githubClient, user, organization)


### PR DESCRIPTION
Hopefully fixes #431 and https://mattermost.atlassian.net/browse/MM-34646.

Perf. note: this will scan the entire KV set of the plugin every time on startup. There is no "all is done, don't do it again" flag for the scan. @hanzei @catalintomai I don't really see it as an issue, but it's easy to persist the state (in a separate KV key?).