### PR TITLE
[GH-66] Improve date format selection UI. Fixes #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ As a system admin, you must create a webhook for each organization you want to r
    - **Content Type:** `application/json`
    - **Secret:** the webhook secret you copied previously.
 6. Select **Let me select individual events** for "Which events would you like to trigger this webhook?".
-7. Select the following events: `Branch or Tag creation`, `Branch or Tag deletion`, `Issue comments`, `Issues`, `Pull requests`, `Pull request review`, `Pull request review comments`, `Pushes`.
+7. Select the following events: `Branch or Tag creation`, `Branch or Tag deletion`, `Issue comments`, `Issues`, `Pull requests`, `Pull request review`, `Pull request review comments`, `Pushes`, `Stars`.
 7. Hit **Add Webhook** to save it.
 
 If you have multiple organizations, repeat the process starting from step 3 to create a webhook for each organization.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/Masterminds/sprig/v3 v3.1.0
-	github.com/google/go-github/v31 v31.0.0
+	github.com/google/go-github/v37 v37.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/mattermost/mattermost-plugin-api v0.0.12-0.20200917103517-788aef584648
 	github.com/mattermost/mattermost-server/v5 v5.28.0

--- a/go.sum
+++ b/go.sum
@@ -288,10 +288,13 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
 github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
+github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
+github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/go.sum
+++ b/go.sum
@@ -288,11 +288,10 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
-github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
 github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
 github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/mattermost/mattermost-plugin-api/experimental/command"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
@@ -22,6 +22,7 @@ const (
 	featureDeletes       = "deletes"
 	featureIssueComments = "issue_comments"
 	featurePullReviews   = "pull_reviews"
+	featureStars         = "stars"
 )
 
 var validFeatures = map[string]bool{
@@ -33,6 +34,7 @@ var validFeatures = map[string]bool{
 	featureDeletes:       true,
 	featureIssueComments: true,
 	featurePullReviews:   true,
+	featureStars:         true,
 }
 
 const (

--- a/server/plugin/permalinks.go
+++ b/server/plugin/permalinks.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 )
 
 // maxPermalinkReplacements sets the maximum limit to the number of

--- a/server/plugin/permalinks_test.go
+++ b/server/plugin/permalinks_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/pkg/errors"
 )
 
@@ -86,6 +86,10 @@ func (s *Subscription) IssueComments() bool {
 
 func (s *Subscription) PullReviews() bool {
 	return strings.Contains(s.Features, "pull_reviews")
+}
+
+func (s *Subscription) Stars() bool {
+	return strings.Contains(s.Features, "stars")
 }
 
 func (s *Subscription) Label() string {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -354,10 +354,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 
 	template.Must(masterTemplate.New("newRepoStar").Funcs(funcMap).Parse(`
 {{template "repo" .GetRepo}}
-{{- if eq .GetAction "created" }} Starred
-{{- else }} Unstarred
+{{- if eq .GetAction "created" }} starred
+{{- else }} unstarred
 {{- end }} by {{template "user" .GetSender}}
-Now, **{{.GetRepo.GetStargazersCount}}** Stars.`))
+It now has **{{.GetRepo.GetStargazersCount}}** Stars.`))
 }
 
 func registerGitHubToUsernameMappingCallback(callback func(string) string) {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -351,6 +351,13 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 		"  * `/github mute add [username]` - add a GitHub user to your muted list\n" +
 		"  * `/github mute delete [username]` - remove a GitHub user from your muted list\n" +
 		"  * `/github mute delete-all` - unmute all GitHub users\n"))
+
+	template.Must(masterTemplate.New("newRepoStar").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}}
+{{- if eq .GetAction "created" }} Starred
+{{- else }} Unstarred
+{{- end }} by {{template "user" .GetSender}}
+Now, **{{.GetRepo.GetStargazersCount}}** Stars.`))
 }
 
 func registerGitHubToUsernameMappingCallback(callback func(string) string) {

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/stretchr/testify/require"
 )
 
 var repo = github.Repository{
-	FullName: sToP("mattermost-plugin-github"),
-	HTMLURL:  sToP("https://github.com/mattermost/mattermost-plugin-github"),
+	FullName:        sToP("mattermost-plugin-github"),
+	StargazersCount: iToP(1),
+	HTMLURL:         sToP("https://github.com/mattermost/mattermost-plugin-github"),
 }
 
 var pushEventRepository = github.PushEventRepository{
@@ -647,6 +648,20 @@ func TestDeletedMessageTemplate(t *testing.T) {
 		Ref:     sToP("branchname"),
 		RefType: sToP("branch"),
 		Sender:  &user,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestRepoStarTemplate(t *testing.T) {
+	expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Starred by [panda](https://github.com/panda)
+Now, **1** Stars.`
+
+	actual, err := renderTemplate("newRepoStar", &github.StarEvent{
+		Action: sToP("created"),
+		Repo:   &repo,
+		Sender: &user,
 	})
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Now, a Mattermost channel can subscribe to Github _Star_ events for a repository.
Channel is notified whenever some one **stars or unstars** a repository.
- Updates dependency `go-github` from version 31 to 37(latest)
  _Reason: `github.StarEvent` is not implemented by old version of dependency._

#### Testing notes
- Once we add `Stars` event to the respective webhook,
![Screenshot_72](https://user-images.githubusercontent.com/85980820/130805083-b35f79d8-d217-46d6-a75b-fc2f5de21170.png)
-  We can subscribe for Star events for that repository by subscribe command.
- Whenever someone stars or unstars the repo we receive notification in channel:
![Screenshot_71](https://user-images.githubusercontent.com/85980820/130804912-d630a68f-a394-4fcc-bd81-f2599119c40b.png)


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/444
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->


