### PR TITLE
Fix- Unable to slect repo from create issue modal

### DIFF
--- a/webapp/src/components/github_repo_selector/github_repo_selector.jsx
+++ b/webapp/src/components/github_repo_selector/github_repo_selector.jsx
@@ -39,7 +39,7 @@ export default class GithubRepoSelector extends PureComponent {
     }
 
     render() {
-        const repoOptions = this.props.yourRepos.map((item) => ({value: item.name, label: item.full_name}));
+        const repoOptions = this.props.yourRepos.map((item) => ({value: item.full_name, label: item.full_name}));
 
         return (
             <div className={'form-group margin-bottom x3'}>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->
### Testing Notes:

Install and configure GitHub 2.1.0
Enable the plugin
Connect a test user
Open the create modal either by selecting create from a post or by typing /github iccue create
Open the repo drop down list and select any repo
#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fix #491 
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

