### PR TITLE
[issue - 493]Organization lock incorrectly validates against valid repos if org name is mixed case #493

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -351,8 +351,9 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 	if err := p.Subscribe(ctx, githubClient, args.UserId, owner, repo, args.ChannelId, features, flags); err != nil {
 		return err.Error()
 	}
+	repoLink := p.getBaseURL() + owner + "/" + repo
 
-	msg := fmt.Sprintf("Successfully subscribed to %s.", repo)
+	msg := fmt.Sprintf("Successfully subscribed to [%s](%s).", repo, repoLink)
 
 	ghRepo, _, err := githubClient.Repositories.Get(ctx, owner, repo)
 	if err != nil {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -680,7 +680,7 @@ func (p *Plugin) checkOrg(org string) error {
 	config := p.getConfiguration()
 
 	configOrg := strings.TrimSpace(config.GitHubOrg)
-	if configOrg != "" && configOrg != org {
+	if configOrg != "" && configOrg != org && strings.ToLower(configOrg) != org {
 		return errors.Errorf("only repositories in the %v organization are supported", configOrg)
 	}
 

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -114,6 +114,9 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		return errors.Errorf("invalid repository")
 	}
 
+	lowerOwner := strings.ToLower(owner)
+	lowerRepo := strings.ToLower(repo)
+
 	if err := p.checkOrg(owner); err != nil {
 		return errors.Wrap(err, "organization not supported")
 	}
@@ -152,11 +155,11 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		ChannelID:  channelID,
 		CreatorID:  userID,
 		Features:   features,
-		Repository: fullNameFromOwnerAndRepo(owner, repo),
+		Repository: fullNameFromOwnerAndRepo(lowerOwner, lowerRepo),
 		Flags:      flags,
 	}
 
-	if err := p.AddSubscription(fullNameFromOwnerAndRepo(owner, repo), sub); err != nil {
+	if err := p.AddSubscription(fullNameFromOwnerAndRepo(lowerOwner, lowerRepo), sub); err != nil {
 		return errors.Wrap(err, "could not add subscription")
 	}
 

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -114,8 +114,8 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		return errors.Errorf("invalid repository")
 	}
 
-	lowerOwner := strings.ToLower(owner)
-	lowerRepo := strings.ToLower(repo)
+	owner = strings.ToLower(owner)
+	repo = strings.ToLower(repo)
 
 	if err := p.checkOrg(owner); err != nil {
 		return errors.Wrap(err, "organization not supported")
@@ -155,11 +155,11 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		ChannelID:  channelID,
 		CreatorID:  userID,
 		Features:   features,
-		Repository: fullNameFromOwnerAndRepo(lowerOwner, lowerRepo),
+		Repository: fullNameFromOwnerAndRepo(owner, repo),
 		Flags:      flags,
 	}
 
-	if err := p.AddSubscription(fullNameFromOwnerAndRepo(lowerOwner, lowerRepo), sub); err != nil {
+	if err := p.AddSubscription(fullNameFromOwnerAndRepo(owner, repo), sub); err != nil {
 		return errors.Wrap(err, "could not add subscription")
 	}
 

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -114,9 +114,6 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 		return errors.Errorf("invalid repository")
 	}
 
-	owner = strings.ToLower(owner)
-	repo = strings.ToLower(repo)
-
 	if err := p.checkOrg(owner); err != nil {
 		return errors.Wrap(err, "organization not supported")
 	}


### PR DESCRIPTION
Removed the convert logic which converts repo and org to lowercase

ticket here

Fixes #493 