### PR TITLE
Feature: Subscribe to Merged PR's only.

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -16,6 +16,7 @@ const (
 	featureIssueCreation = "issue_creations"
 	featureIssues        = "issues"
 	featurePulls         = "pulls"
+	featurePullsMerged   = "pulls_merged"
 	featurePushes        = "pushes"
 	featureCreates       = "creates"
 	featureDeletes       = "deletes"
@@ -28,6 +29,7 @@ var validFeatures = map[string]bool{
 	featureIssueCreation: true,
 	featureIssues:        true,
 	featurePulls:         true,
+	featurePullsMerged:   true,
 	featurePushes:        true,
 	featureCreates:       true,
 	featureDeletes:       true,
@@ -301,6 +303,9 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 			fs := strings.Split(features, ",")
 			if SliceContainsString(fs, featureIssues) && SliceContainsString(fs, featureIssueCreation) {
 				return "Feature list cannot contain both issue and issue_creations"
+			}
+			if SliceContainsString(fs, featurePulls) && SliceContainsString(fs, featurePullsMerged) {
+				return "Feature list cannot contain both pulls and pulls_merged"
 			}
 			ok, ifs := validateFeatures(fs)
 			if !ok {
@@ -631,7 +636,7 @@ func getAutocompleteData(config *Configuration) *model.AutocompleteData {
 
 	subscriptionsAdd := model.NewAutocompleteData("add", "[owner/repo] [features] [flags]", "Subscribe the current channel to receive notifications about opened pull requests and issues for an organization or repository. [features] and [flags] are optional arguments")
 	subscriptionsAdd.AddTextArgument("Owner/repo to subscribe to", "[owner/repo]", "")
-	subscriptionsAdd.AddTextArgument("Comma-delimited list of one or more of: issues, pulls, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, label:\"<labelname>\". Defaults to pulls,issues,creates,deletes", "[features] (optional)", `/[^,-\s]+(,[^,-\s]+)*/`)
+	subscriptionsAdd.AddTextArgument("Comma-delimited list of one or more of: issues, pulls, pulls_merged, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, label:\"<labelname>\". Defaults to pulls,issues,creates,deletes", "[features] (optional)", `/[^,-\s]+(,[^,-\s]+)*/`)
 	if config.GitHubOrg != "" {
 		exclude := []model.AutocompleteListItem{
 			{

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -60,6 +60,10 @@ func (s *Subscription) Pulls() bool {
 	return strings.Contains(s.Features, featurePulls)
 }
 
+func (s *Subscription) PullsMerged() bool {
+	return strings.Contains(s.Features, "pulls_merged")
+}
+
 func (s *Subscription) IssueCreations() bool {
 	return strings.Contains(s.Features, "issue_creations")
 }

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -331,6 +331,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 		"  * `features` is a comma-delimited list of one or more the following:\n" +
 		"    * `issues` - includes new and closed issues\n" +
 		"    * `pulls` - includes new and closed pull requests\n" +
+		"    * `pulls_merged` - includes merged pull requests only\n" +
 		"    * `pushes` - includes pushes\n" +
 		"    * `creates` - includes branch and tag creations\n" +
 		"    * `deletes` - includes branch and tag deletions\n" +

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -269,7 +269,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			continue
 		}
 
-		if sub.PullsMerged() && (action == "opened" || action == "labeled" || action != "closed") {
+		if sub.PullsMerged() && action != "closed" {
 			continue
 		}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -265,7 +265,11 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 	}
 
 	for _, sub := range subs {
-		if !sub.Pulls() {
+		if !sub.Pulls() && !sub.PullsMerged() {
+			continue
+		}
+
+		if sub.PullsMerged() && action != "opened" && action != "labeled" && action != "closed" {
 			continue
 		}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -269,7 +269,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			continue
 		}
 
-		if sub.PullsMerged() && action != "opened" && action != "labeled" && action != "closed" {
+		if sub.PullsMerged() && (action == "opened" || action == "labeled" || action != "closed" ) {
 			continue
 		}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -269,7 +269,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			continue
 		}
 
-		if sub.PullsMerged() && (action == "opened" || action == "labeled" || action != "closed" ) {
+		if sub.PullsMerged() && (action == "opened" || action == "labeled" || action != "closed") {
 			continue
 		}
 


### PR DESCRIPTION
#### Summary

This PR adds a new feature which enables the user to subscribe only to see when Pull requests are merged and not when they are created, updated or labelled. For use case and other details, refer to #481.

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-plugin-github/issues/481

