### PR TITLE
GitHub LHS icon will not show on 1st login until the browser is refreshed

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -481,13 +481,13 @@ func (p *Plugin) getConnected(c *Context, w http.ResponseWriter, r *http.Request
 	config := p.getConfiguration()
 
 	type ConnectedResponse struct {
-		Connected         bool          `json:"connected"`
-		GitHubUsername    string        `json:"github_username"`
-		GitHubClientID    string        `json:"github_client_id"`
-		EnterpriseBaseURL string        `json:"enterprise_base_url,omitempty"`
-		Organization      string        `json:"organization"`
-		UserSettings      *UserSettings `json:"user_settings"`
-		PluginSettings    Settings      `json:"plugin_settings"`
+		Connected         bool               `json:"connected"`
+		GitHubUsername    string             `json:"github_username"`
+		GitHubClientID    string             `json:"github_client_id"`
+		EnterpriseBaseURL string             `json:"enterprise_base_url,omitempty"`
+		Organization      string             `json:"organization"`
+		UserSettings      *UserSettings      `json:"user_settings"`
+		PluginSettings    ClientSafeSettings `json:"plugin_settings"`
 	}
 
 	resp := &ConnectedResponse{
@@ -563,8 +563,8 @@ func (p *Plugin) getConnected(c *Context, w http.ResponseWriter, r *http.Request
 	p.writeJSON(w, resp)
 }
 
-func (p *Plugin) getPluginSettings() Settings {
-	pluginSettings := Settings{
+func (p *Plugin) getPluginSettings() ClientSafeSettings {
+	pluginSettings := ClientSafeSettings{
 		LeftSidebarEnabled: p.getConfiguration().EnableLeftSidebar,
 	}
 

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -316,6 +316,10 @@ type UserSettings struct {
 	Notifications         bool   `json:"notifications"`
 }
 
+type Settings struct {
+	LeftSidebarEnabled bool `json:"left_sidebar_enabled"`
+}
+
 func (p *Plugin) storeGitHubUserInfo(info *GitHubUserInfo) error {
 	config := p.getConfiguration()
 

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -316,7 +316,7 @@ type UserSettings struct {
 	Notifications         bool   `json:"notifications"`
 }
 
-type Settings struct {
+type ClientSafeSettings struct {
 	LeftSidebarEnabled bool `json:"left_sidebar_enabled"`
 }
 

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -426,5 +426,5 @@ export async function getSettings() {
     } catch (error) {
         return {error};
     }
-    return {data};
+    return data;
 }

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -418,13 +418,3 @@ export function attachCommentToIssue(payload) {
         return {data};
     };
 }
-
-export async function getSettings() {
-    let data;
-    try {
-        data = await Client.getSettings();
-    } catch (error) {
-        return {error};
-    }
-    return data;
-}

--- a/webapp/src/components/sidebar_header/index.js
+++ b/webapp/src/components/sidebar_header/index.js
@@ -3,12 +3,18 @@
 
 import {connect} from 'react-redux';
 
+import {pluginSettings} from '../../selectors';
+
 import SidebarHeader from './sidebar_header.jsx';
 
 function mapStateToProps(state) {
     const members = state.entities.teams.myMembers || {};
+
+    const sidebarEnabled = pluginSettings(state).left_sidebar_enabled;
+    const show = sidebarEnabled && Object.keys(members).length <= 1;
+
     return {
-        show: Object.keys(members).length <= 1,
+        show,
     };
 }
 

--- a/webapp/src/components/team_sidebar/index.js
+++ b/webapp/src/components/team_sidebar/index.js
@@ -3,12 +3,18 @@
 
 import {connect} from 'react-redux';
 
+import {pluginSettings} from '../../selectors';
+
 import TeamSidebar from './team_sidebar.jsx';
 
 function mapStateToProps(state) {
     const members = state.entities.teams.myMembers || {};
+
+    const sidebarEnabled = pluginSettings(state).left_sidebar_enabled;
+    const show = sidebarEnabled && Object.keys(members).length > 1;
+
     return {
-        show: Object.keys(members).length > 1,
+        show,
     };
 }
 

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -12,9 +12,9 @@ import SidebarRight from './components/sidebar_right';
 import LinkTooltip from './components/link_tooltip';
 import Reducer from './reducers';
 import Client from './client';
-import {getConnected, setShowRHSAction, getSettings} from './actions';
+import {getConnected, setShowRHSAction} from './actions';
 import {handleConnect, handleDisconnect, handleOpenCreateIssueModal, handleReconnect, handleRefresh} from './websocket';
-import {getServerRoute, isLoggedIn} from './selectors';
+import {getServerRoute} from './selectors';
 import {id as pluginId} from './manifest';
 
 let activityFunc;
@@ -23,20 +23,13 @@ const activityTimeout = 60 * 60 * 1000; // 1 hour
 
 class PluginClass {
     async initialize(registry, store) {
-        const userLoggedIn = isLoggedIn(store.getState());
-        let settings = false;
         registry.registerReducer(Reducer);
         Client.setServerRoute(getServerRoute(store.getState()));
 
-        if (userLoggedIn) {
-            settings = await getSettings(store.getState);
-            await getConnected(true)(store.dispatch, store.getState);
-        }
+        await getConnected(true)(store.dispatch, store.getState);
 
-        if (!userLoggedIn || (settings !== false && settings.left_sidebar_enabled)) {
-            registry.registerLeftSidebarHeaderComponent(SidebarHeader);
-            registry.registerBottomTeamSidebarComponent(TeamSidebar);
-        }
+        registry.registerLeftSidebarHeaderComponent(SidebarHeader);
+        registry.registerBottomTeamSidebarComponent(TeamSidebar);
         registry.registerPopoverUserAttributesComponent(UserAttribute);
         registry.registerRootComponent(CreateIssueModal);
         registry.registerPostDropdownMenuComponent(CreateIssuePostMenuAction);

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -48,10 +48,19 @@ function username(state = '', action) {
     }
 }
 
-function settings(state = {sidebar_buttons: Constants.SETTING_BUTTONS_TEAM, daily_reminder: true, notifications: true}, action) {
+function userSettings(state = {sidebar_buttons: Constants.SETTING_BUTTONS_TEAM, daily_reminder: true, notifications: true}, action) {
     switch (action.type) {
     case ActionTypes.RECEIVED_CONNECTED:
-        return action.data.settings;
+        return action.data.user_settings;
+    default:
+        return state;
+    }
+}
+
+function pluginSettings(state = {left_sidebar_enabled: true}, action) {
+    switch (action.type) {
+    case ActionTypes.RECEIVED_CONNECTED:
+        return action.data.plugin_settings;
     default:
         return state;
     }
@@ -224,7 +233,8 @@ export default combineReducers({
     enterpriseURL,
     organization,
     username,
-    settings,
+    userSettings,
+    pluginSettings,
     clientId,
     reviews,
     reviewsDetails,

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -19,6 +19,4 @@ export const getServerRoute = (state) => {
     return basePath;
 };
 
-export function isLoggedIn(state) {
-    return state.entities.users.currentUserId !== '';
-}
+export const pluginSettings = (state) => getPluginState(state).pluginSettings;

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -18,3 +18,7 @@ export const getServerRoute = (state) => {
 
     return basePath;
 };
+
+export function isLoggedIn(state) {
+    return state.entities.users.currentUserId !== '';
+}

--- a/webapp/src/websocket/index.js
+++ b/webapp/src/websocket/index.js
@@ -19,10 +19,9 @@ export function handleConnect(store) {
         if (!msg.data) {
             return;
         }
-
         store.dispatch({
             type: ActionTypes.RECEIVED_CONNECTED,
-            data: {...msg.data, settings: {sidebar_buttons: Constants.SETTING_BUTTONS_TEAM, daily_reminder: true}},
+            data: {...msg.data, user_settings: {sidebar_buttons: Constants.SETTING_BUTTONS_TEAM, daily_reminder: true}},
         });
     };
 }

--- a/webapp/src/websocket/index.js
+++ b/webapp/src/websocket/index.js
@@ -21,7 +21,7 @@ export function handleConnect(store) {
         }
         store.dispatch({
             type: ActionTypes.RECEIVED_CONNECTED,
-            data: {...msg.data, user_settings: {sidebar_buttons: Constants.SETTING_BUTTONS_TEAM, daily_reminder: true}},
+            data: {...msg.data, settings: {sidebar_buttons: Constants.SETTING_BUTTONS_TEAM, daily_reminder: true}},
         });
     };
 }


### PR DESCRIPTION
## Discussion
#### Original Issue
> When a user fist logs into a Mattermost in a new browser they will not see the GitHub icons (connect or Pulls, Issues,Notifications etc..) on the LHS or team sidebar.

#### Cause
While initializing the plugin this method is called to fetch settings and get `left_sidebar_enabled`:
```javascript
await getSettings(store.getState);
```
But it fails if the user is not logged in, since auth is required to fetch settings for the plugin.
As you may observe, I handled that case so no HTTP requests to get settings will fail and load sidebar if the user is not logged in. Since at the time of initialization while user is not logged in, we don't have access to preferences for the plugin.
Resultant would be:
sidebar will load for the first time even if disabled if the user logs in for the first time.

### Queries
- Why this setting is behind auth?
- Inspected state, found this
![Screenshot_9](https://user-images.githubusercontent.com/85980820/142970122-6e4d10b1-c667-4e61-9592-230c9eee92f9.png)
How is `left_sidebar_enabled` different from these settings ?
#### Ticket Link
https://github.com/mattermost/mattermost-plugin-github/issues/492

