### PR TITLE
[GH-520] Fix subscriptions add command parameter parsing error

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -328,7 +328,6 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 	ctx := context.Background()
 	githubClient := p.githubConnectUser(ctx, userInfo)
 
-
 	owner, repo := parseOwnerAndRepo(parameters[0], p.getBaseURL())
 	if repo == "" {
 		if err := p.SubscribeOrg(ctx, githubClient, args.UserId, owner, args.ChannelId, features, flags); err != nil {

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -233,7 +233,7 @@ func (p *Plugin) handleSubscriptions(c *plugin.Context, args *model.CommandArgs,
 
 	command := parameters[0]
 
-	if command == "list" {
+	if command == list {
 		return p.handleSubscriptionsList(c, args, parameters, userInfo)
 	}
 

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -232,11 +232,18 @@ func (p *Plugin) handleSubscriptions(c *plugin.Context, args *model.CommandArgs,
 	}
 
 	command := parameters[0]
+
+    if command == "list" {
+		return p.handleSubscriptionsList(c, args, parameters, userInfo)
+    }
+
+    if len(parameters) == 1 {
+        return "Please specify a repository"
+    }
+
 	parameters = parameters[1:]
 
 	switch {
-	case command == "list":
-		return p.handleSubscriptionsList(c, args, parameters, userInfo)
 	case command == "add":
 		return p.handleSubscribesAdd(c, args, parameters, userInfo)
 	case command == "delete":
@@ -320,6 +327,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 
 	ctx := context.Background()
 	githubClient := p.githubConnectUser(ctx, userInfo)
+
 
 	owner, repo := parseOwnerAndRepo(parameters[0], p.getBaseURL())
 	if repo == "" {

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -233,13 +233,13 @@ func (p *Plugin) handleSubscriptions(c *plugin.Context, args *model.CommandArgs,
 
 	command := parameters[0]
 
-    if command == "list" {
+	if command == "list" {
 		return p.handleSubscriptionsList(c, args, parameters, userInfo)
-    }
+	}
 
-    if len(parameters) == 1 {
-        return "Please specify a repository"
-    }
+	if len(parameters) == 1 {
+		return "Please specify a repository"
+	}
 
 	parameters = parameters[1:]
 

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -232,18 +232,11 @@ func (p *Plugin) handleSubscriptions(c *plugin.Context, args *model.CommandArgs,
 	}
 
 	command := parameters[0]
-
-	if command == list {
-		return p.handleSubscriptionsList(c, args, parameters, userInfo)
-	}
-
-	if len(parameters) == 1 {
-		return "Please specify a repository"
-	}
-
 	parameters = parameters[1:]
 
 	switch {
+    case command == "list":
+		return p.handleSubscriptionsList(c, args, parameters, userInfo)
 	case command == "add":
 		return p.handleSubscribesAdd(c, args, parameters, userInfo)
 	case command == "delete":
@@ -286,6 +279,10 @@ func (p *Plugin) handleSubscriptionsList(_ *plugin.Context, args *model.CommandA
 }
 
 func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string {
+	if len(parameters) == 0 {
+		return "Please specify a repository"
+	}
+
 	features := "pulls,issues,creates,deletes"
 	flags := SubscriptionFlags{}
 

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -235,7 +235,7 @@ func (p *Plugin) handleSubscriptions(c *plugin.Context, args *model.CommandArgs,
 	parameters = parameters[1:]
 
 	switch {
-    case command == "list":
+	case command == "list":
 		return p.handleSubscriptionsList(c, args, parameters, userInfo)
 	case command == "add":
 		return p.handleSubscribesAdd(c, args, parameters, userInfo)

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -280,7 +280,7 @@ func (p *Plugin) handleSubscriptionsList(_ *plugin.Context, args *model.CommandA
 
 func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string {
 	if len(parameters) == 0 {
-		return "Please specify a repository"
+		return "Please specify a repository."
 	}
 
 	features := "pulls,issues,creates,deletes"


### PR DESCRIPTION
When using the `subscriptions add/delete` commands, the plugin did not correctly check the length of the parameters, causing the plugin to error when not specifying a repository. I fixed it :)

To reproduce, type one of the following into the chat with the GitHub plugin enabled:
- `/github subscriptions add`
- `/github subscriptions delete`

Fixes https://github.com/mattermost/mattermost-plugin-github/issues/520