### PR TITLE
Fixed #535: subtype is 'text' now

### DIFF
--- a/server/plugin/flows.go
+++ b/server/plugin/flows.go
@@ -496,7 +496,7 @@ func (fm *FlowManager) stepOAuthInput() flow.Step {
 						DisplayName: "GitHub OAuth Client Secret",
 						Name:        "client_secret",
 						Type:        "text",
-						SubType:     "password",
+						SubType:     "text",
 						Placeholder: "Enter GitHub OAuth Client Secret",
 					},
 				},


### PR DESCRIPTION
Fixed #535 by removing the `password` Subtype and replacing it with `text`.