### PR TITLE
Don't close message channel if client doesn't want to recive any longer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v41 v41.0.0
 	github.com/gorilla/mux v1.8.0
-	github.com/mattermost/mattermost-plugin-api v0.0.25-0.20220211190716-3a2a7cd9324a
+	github.com/mattermost/mattermost-plugin-api v0.0.25
 	github.com/mattermost/mattermost-server/v6 v6.3.0
 	github.com/microcosm-cc/bluemonday v1.0.18
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v41 v41.0.0
 	github.com/gorilla/mux v1.8.0
-	github.com/mattermost/mattermost-plugin-api v0.0.25
+	github.com/mattermost/mattermost-plugin-api v0.0.26
 	github.com/mattermost/mattermost-server/v6 v6.3.0
 	github.com/microcosm-cc/bluemonday v1.0.18
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -949,8 +949,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3zBew=
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
-github.com/mattermost/mattermost-plugin-api v0.0.25-0.20220211190716-3a2a7cd9324a h1:ng2Y2ESXBY9K3eOjjsz+uIjFkda3ZXrjLOzofckPKl8=
-github.com/mattermost/mattermost-plugin-api v0.0.25-0.20220211190716-3a2a7cd9324a/go.mod h1:MM+tZ+36Obm9jqcveoxY2RFbwLaZKZUgR1zUlc0UBYw=
+github.com/mattermost/mattermost-plugin-api v0.0.25 h1:OrKYQFceERf8+cNzGf9N8LOU/QYzB8kNRr7vPLcLXLo=
+github.com/mattermost/mattermost-plugin-api v0.0.25/go.mod h1:MM+tZ+36Obm9jqcveoxY2RFbwLaZKZUgR1zUlc0UBYw=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20220210052000-0d67995eb491 h1:OsIVqOSO2Dn6XNYKBHKbcFzDQIL5qwrocJwWTbTLAS8=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20220210052000-0d67995eb491/go.mod h1:5iM6uoWoD+Ywp/497R+iCP2cBt5dTpn8d96kX+EPwFA=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=

--- a/go.sum
+++ b/go.sum
@@ -949,8 +949,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3zBew=
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
-github.com/mattermost/mattermost-plugin-api v0.0.25 h1:OrKYQFceERf8+cNzGf9N8LOU/QYzB8kNRr7vPLcLXLo=
-github.com/mattermost/mattermost-plugin-api v0.0.25/go.mod h1:MM+tZ+36Obm9jqcveoxY2RFbwLaZKZUgR1zUlc0UBYw=
+github.com/mattermost/mattermost-plugin-api v0.0.26 h1:h43yUMkRbAmcFYtqbeUdIxxMKp6kRZUebVI6F9ezZpU=
+github.com/mattermost/mattermost-plugin-api v0.0.26/go.mod h1:MM+tZ+36Obm9jqcveoxY2RFbwLaZKZUgR1zUlc0UBYw=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20220210052000-0d67995eb491 h1:OsIVqOSO2Dn6XNYKBHKbcFzDQIL5qwrocJwWTbTLAS8=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20220210052000-0d67995eb491/go.mod h1:5iM6uoWoD+Ywp/497R+iCP2cBt5dTpn8d96kX+EPwFA=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=

--- a/server/plugin/cluster.go
+++ b/server/plugin/cluster.go
@@ -64,6 +64,6 @@ func (p *Plugin) HandleClusterEvent(ev model.PluginClusterEvent) {
 
 		p.oauthBroker.publishOAuthComplete(event.UserID, event.Err, true)
 	default:
-		p.API.LogWarn("unknown cluset event", "id", ev.Id)
+		p.API.LogWarn("unknown cluster event", "id", ev.Id)
 	}
 }

--- a/server/plugin/flows.go
+++ b/server/plugin/flows.go
@@ -470,7 +470,7 @@ You must first register the Mattermost GitHub Plugin as an authorized OAuth app.
 	return flow.NewStep(stepOAuthInfo).
 		WithPretext(oauthPretext).
 		WithText(oauthMessage).
-		WithImage(fm.pluginURL, "public/new-oauth-application.png").
+		WithImage("public/new-oauth-application.png").
 		WithButton(continueButton("")).
 		WithButton(cancelButton())
 }

--- a/server/plugin/flows.go
+++ b/server/plugin/flows.go
@@ -172,7 +172,7 @@ const (
 
 func cancelButton() flow.Button {
 	return flow.Button{
-		Name:    "Cancel",
+		Name:    "Cancel setup",
 		Color:   flow.ColorDanger,
 		OnClick: flow.Goto(stepCancel),
 	}

--- a/server/plugin/oauth.go
+++ b/server/plugin/oauth.go
@@ -44,7 +44,6 @@ func (ob *OAuthBroker) UnsubscribeOAuthComplete(userID string, ch <-chan error) 
 
 	for i, sub := range ob.oauthCompleteSubs[userID] {
 		if sub == ch {
-			close(sub)
 			ob.oauthCompleteSubs[userID] = append(ob.oauthCompleteSubs[userID][:i], ob.oauthCompleteSubs[userID][i+1:]...)
 			break
 		}

--- a/server/plugin/oauth.go
+++ b/server/plugin/oauth.go
@@ -58,13 +58,11 @@ func (ob *OAuthBroker) publishOAuthComplete(userID string, err error, fromCluste
 		return
 	}
 
-	for _, userSubs := range ob.oauthCompleteSubs {
-		for _, sub := range userSubs {
-			// non-blocking send
-			select {
-			case sub <- err:
-			default:
-			}
+	for _, userSub := range ob.oauthCompleteSubs[userID] {
+		// non-blocking send
+		select {
+		case userSub <- err:
+		default:
 		}
 	}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -103,7 +103,6 @@ func (wb *WebhookBroker) UnsubscribePings(ch <-chan *github.PingEvent) {
 
 	for i, sub := range wb.pingSubs {
 		if sub == ch {
-			close(sub)
 			wb.pingSubs = append(wb.pingSubs[:i], wb.pingSubs[i+1:]...)
 			break
 		}

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha1" //nolint:gosec // GitHub webhooks are signed using sha1 https://developer.github.com/webhooks/.
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -147,7 +147,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	config := p.getConfiguration()
 
 	signature := r.Header.Get("X-Hub-Signature")
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Bad request body", http.StatusBadRequest)
 		return


### PR DESCRIPTION
#### Summary
If the plugin gets disabled while a reviving channel created by the broker is waiting for a message, a double `close` happens as the broker closes the channel and then the consumer closes it again in `UnsubscribeX`. Given that only the sender should close a channel, `UnsubscribeX` doesn't do that with this PR.

The PR also includes various other fixes.

#### Ticket Link
None