### PR TITLE
[GH-484] Add Collapsed Flag + Make Flags Accept Boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ When you’ve tested the plugin and confirmed it’s working, notify your team s
    /github subscriptions add mattermost/mattermost-server issues,pulls,issue_comments,label:"Help Wanted"
    ```
   - The following flags are supported:
-     - `--exclude-org-member`: events triggered by organization members will not be delivered. It will be locked to the organization provided in the plugin configuration and it will only work for users whose membership is public. Note that organization members and collaborators are not the same.
+     - `--exclude-org-member [true/false]`: events triggered by organization members will not be delivered. It will be locked to the organization provided in the plugin configuration and it will only work for users whose membership is public. Note that organization members and collaborators are not the same.
+     - `--collapsed [true/false]`: All notifications about events from the plugin will be collapsed and save space if set to true. The default is false, which shows large, informational messages for notifications, taking up more space.
    
 * __Get to do items__ - Use `/github todo` to get an ephemeral message with items to do in GitHub, including a list of unread messages and pull requests awaiting your review.
 * __Update settings__ - Use `/github settings` to update your settings for notifications and daily reminders.

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -191,6 +191,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{.GetPullRequest.GetBody | removeComments | replaceAllGitHubUsernames}}
 `))
 
+	template.Must(masterTemplate.New("newPRCollapsed").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}} Pull request {{template "pullRequest" .GetPullRequest}} opened by {{template "user" .GetSender}}.
+`))
+
 	template.Must(masterTemplate.New("closedPR").Funcs(funcMap).Parse(`
 {{template "repo" .GetRepo}} Pull request {{template "pullRequest" .GetPullRequest}} was
 {{- if .GetPullRequest.GetMerged }} merged
@@ -202,6 +206,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 #### {{.GetPullRequest.GetTitle}}
 ##### {{template "eventRepoPullRequest" .}}
 #pull-request-labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}}
+`))
+
+	template.Must(masterTemplate.New("pullRequestLabelledCollapsed").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}} Pull request {{template "pullRequest" .GetPullRequest}} labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}}
 `))
 
 	template.Must(masterTemplate.New("pullRequestMentionNotification").Funcs(funcMap).Parse(`
@@ -218,6 +226,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{.GetIssue.GetBody | removeComments | replaceAllGitHubUsernames}}
 `))
 
+	template.Must(masterTemplate.New("newIssueCollapsed").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}} Issue {{template "issue" .GetIssue}} opened by {{template "user" .GetSender}}.
+`))
+
 	template.Must(masterTemplate.New("closedIssue").Funcs(funcMap).Parse(`
 {{template "repo" .GetRepo}} Issue {{template "issue" .GetIssue}} closed by {{template "user" .GetSender}}.
 `))
@@ -226,6 +238,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 #### {{.GetIssue.GetTitle}}
 ##### {{template "eventRepoIssue" .}}
 #issue-labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}}.
+`))
+
+	template.Must(masterTemplate.New("issueLabelledCollapsed").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}} Issue {{template "issue" .GetIssue}} labeled ` + "`{{.GetLabel.GetName}}`" + ` by {{template "user" .GetSender}}.
 `))
 
 	template.Must(masterTemplate.New("reopenedIssue").Funcs(funcMap).Parse(`
@@ -352,6 +368,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 		"    * Defaults to `pulls,issues,creates,deletes`\n" +
 		"  * `flags` currently supported:\n" +
 		"    * `--exclude-org-member` - events triggered by organization members will not be delivered (the GitHub organization config should be set, otherwise this flag has not effect)\n" +
+		"    * `--collapsed` - makes normally expanded notifications compact to save space (the default is for new issues and pull requests to show the expanded notification)\n" +
 		"* `/github subscriptions delete owner[/repo]` - Unsubscribe the current channel from a repository\n" +
 		"* `/github me` - Display the connected GitHub account\n" +
 		"* `/github settings [setting] [value]` - Update your user settings\n" +

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -311,6 +311,20 @@ git-get-head gets the non-sent upstream heads inside the stashed non-cleaned app
 	})
 }
 
+func TestNewPRCollapsedMessageTemplate(t *testing.T) {
+	expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Pull request [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42) opened by [panda](https://github.com/panda).
+`
+
+	actual, err := renderTemplate("newPRCollapsed", &github.PullRequestEvent{
+		Repo:        &repo,
+		PullRequest: &pullRequest,
+		Sender:      &user,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
 func TestClosedPRMessageTemplate(t *testing.T) {
 	t.Run("merged", func(t *testing.T) {
 		expected := `
@@ -349,6 +363,23 @@ func TestPullRequestLabelledTemplate(t *testing.T) {
 `
 
 	actual, err := renderTemplate("pullRequestLabelled", &github.PullRequestEvent{
+		Repo:        &repo,
+		PullRequest: &pullRequest,
+		Label: &github.Label{
+			Name: sToP("label-name"),
+		},
+		Sender: &user,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestPullRequestLabelledCollapsedTemplate(t *testing.T) {
+	expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Pull request [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42) labeled ` + "`label-name`" + ` by [panda](https://github.com/panda).
+`
+
+	actual, err := renderTemplate("pullRequestLabelledCollapsed", &github.PullRequestEvent{
 		Repo:        &repo,
 		PullRequest: &pullRequest,
 		Label: &github.Label{
@@ -439,6 +470,20 @@ git-get-head sounds like a great feature we should support
 	})
 }
 
+func TestNewIssueCollapsedTemplate(t *testing.T) {
+	expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Issue [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1) opened by [panda](https://github.com/panda).
+`
+
+	actual, err := renderTemplate("newIssueCollapsed", &github.IssuesEvent{
+		Repo:   &repo,
+		Issue:  &issue,
+		Sender: &user,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
 func TestClosedIssueTemplate(t *testing.T) {
 	expected := `
 [\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Issue [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1) closed by [panda](https://github.com/panda).
@@ -475,6 +520,23 @@ func TestIssueLabelledTemplate(t *testing.T) {
 `
 
 	actual, err := renderTemplate("issueLabelled", &github.IssuesEvent{
+		Repo:  &repo,
+		Issue: &issue,
+		Label: &github.Label{
+			Name: sToP("label-name"),
+		},
+		Sender: &user,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func TestIssueLabelledCollapsedTemplate(t *testing.T) {
+	expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Issue [#1 Implement git-get-head](https://github.com/mattermost/mattermost-plugin-github/issues/1) labeled ` + "`label-name`" + ` by [panda](https://github.com/panda).
+`
+
+	actual, err := renderTemplate("issueLabelledCollapsed", &github.IssuesEvent{
 		Repo:  &repo,
 		Issue: &issue,
 		Label: &github.Label{

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -376,7 +376,7 @@ func TestPullRequestLabelledTemplate(t *testing.T) {
 
 func TestPullRequestLabelledCollapsedTemplate(t *testing.T) {
 	expected := `
-[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Pull request [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42) labeled ` + "`label-name`" + ` by [panda](https://github.com/panda).
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Pull request [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42) labeled ` + "`label-name`" + ` by [panda](https://github.com/panda)
 `
 
 	actual, err := renderTemplate("pullRequestLabelledCollapsed", &github.PullRequestEvent{

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -327,7 +327,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 
 	newPRMessage, err := renderTemplate("newPR", event)
 	if err != nil {
-		p.API.LogWarn("Failed to render newPRCollapsed template", "error", err.Error())
+		p.API.LogWarn("Failed to render newPR template", "error", err.Error())
 		return
 	}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -392,7 +392,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 		}
 
 		switch action {
-		case "labeled":
+		case actionLabeled:
 			if sub.Label() == eventLabel {
 				if sub.CollapseNotifications() {
 					post.Message = pullRequestLabelledCollapsedMessage

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -342,7 +342,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 	if action == "labeled" {
 		pullRequestLabelledMessage, err = renderTemplate("pullRequestLabelled", event)
 		if err != nil {
-			p.API.LogWarn("Failed to render template", "error", err.Error())
+			p.API.LogWarn("Failed to render pullRequestLabelled template", "error", err.Error())
 			return
 		}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -348,7 +348,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 
 		pullRequestLabelledCollapsedMessage, err = renderTemplate("pullRequestLabelledCollapsed", event)
 		if err != nil {
-			p.API.LogWarn("Failed to render template", "error", err.Error())
+			p.API.LogWarn("Failed to render pullRequestLabelledCollapsed template", "error", err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
This addresses https://github.com/mattermost/mattermost-plugin-github/issues/484, which requests a feature that allows for collapsing large notification messages. Examples:
`/github subscriptions add owner/repo pulls,issues --collapsed true`
`/github subscriptions add owner/repo pulls,issues --exclude-org-members true`

When set to true, this flag makes posts that normally use larger text for titles into smaller, inline posts with a less detailed summary of the repo, pr/issue name, label name if applicable, and who the action was committed by. Of course, when set to false, the default behavior is used. Autocomplete behavior for all flags has been added and adjusted to complete possible parameters as well.

To allow for the addition of parameters such as booleans to flags, the behavior for the `--exclude-org-member` flag has changed as well. However, it is also the same logic - you just put `true` or `false` after it to do what you want.

Thanks for reviewing!