### PR TITLE
[issue 558] Duplicate bot DM is being created when a user is mentioned on a PR assigned to the user

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2229,3 +2229,4 @@ sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 willnorris.com/go/gifresize v1.0.0/go.mod h1:eBM8gogBGCcaH603vxSpnfjwXIpq6nmnj/jauBDKtAk=
 willnorris.com/go/imageproxy v0.11.2/go.mod h1:pyA05z6P0nLWX6QmeqMUyK6v9HnWE/bqnPnrzUST0KU=
+

--- a/go.sum
+++ b/go.sum
@@ -2229,4 +2229,3 @@ sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
 willnorris.com/go/gifresize v1.0.0/go.mod h1:eBM8gogBGCcaH603vxSpnfjwXIpq6nmnj/jauBDKtAk=
 willnorris.com/go/imageproxy v0.11.2/go.mod h1:pyA05z6P0nLWX6QmeqMUyK6v9HnWE/bqnPnrzUST0KU=
-

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -895,9 +895,22 @@ func (p *Plugin) handleCommentMentionNotification(event *github.IssueCommentEven
 		Message: message,
 		Type:    "custom_git_mention",
 	}
+	assignees := event.GetIssue().Assignees
 
 	for _, username := range mentionedUsernames {
 		// Don't notify user of their own comment
+		assigneeMentioned := false
+		for _, assignee := range assignees {
+			if username == *assignee.Login {
+				assigneeMentioned = true
+				break
+			}
+		}
+
+		if assigneeMentioned {
+			continue
+		}
+
 		if username == event.GetSender().GetLogin() {
 			continue
 		}


### PR DESCRIPTION
added a check for duplicate notification.


ticket here
Fixes #558 