### PR TITLE
Revert "Add --verbose flag to npm install"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ endif
 ## Ensures NPM dependencies are installed without having to run this all the time.
 webapp/node_modules: $(wildcard webapp/package.json)
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && $(NPM) install --verbose
+	cd webapp && $(NPM) install
 	touch $@
 endif
 


### PR DESCRIPTION
Not longer needed as https://github.com/mattermost/circleci-orbs/pull/31 has been merged.

This PR should not be merged until a new release of the orb has been published.

Reverts mattermost/mattermost-plugin-github#577