### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,6 @@ linters-settings:
     simplify: true
   goimports:
     local-prefixes: github.com/mattermost/mattermost-plugin-github
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
@@ -16,30 +14,31 @@ linters-settings:
       - fieldalignment
   misspell:
     locale: US
+  revive:
+    rules:
+      - name: error-strings
+        disabled: true
 
 linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 issues:

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -73,7 +73,7 @@ func (c *Client) GetConfiguration() (*plugin.Configuration, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (c *Client) GetToken(userID string) (*oauth2.Token, error) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/client/client_test.go
+++ b/server/client/client_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -57,7 +57,7 @@ func TestGetConfiguration(t *testing.T) {
 		require.NoError(t, err)
 
 		pluginAPI := &plugintest.API{}
-		pluginAPI.On("PluginHTTP", mock.AnythingOfType("*http.Request")).Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(b)})
+		pluginAPI.On("PluginHTTP", mock.AnythingOfType("*http.Request")).Return(&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(b)})
 		defer pluginAPI.AssertExpectations(t)
 
 		client := NewPluginClient(pluginAPI)
@@ -91,7 +91,7 @@ func TestGetToken(t *testing.T) {
 		require.NoError(t, err)
 
 		pluginAPI := &plugintest.API{}
-		pluginAPI.On("PluginHTTP", mock.AnythingOfType("*http.Request")).Return(&http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(b)})
+		pluginAPI.On("PluginHTTP", mock.AnythingOfType("*http.Request")).Return(&http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(b)})
 		defer pluginAPI.AssertExpectations(t)
 
 		client := NewPluginClient(pluginAPI)

--- a/server/plugin/api_test.go
+++ b/server/plugin/api_test.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,7 +47,7 @@ func TestWithRecovery(t *testing.T) {
 	resp := w.Result()
 	if resp.Body != nil {
 		defer resp.Body.Close()
-		_, err := io.Copy(ioutil.Discard, resp.Body)
+		_, err := io.Copy(io.Discard, resp.Body)
 		require.NoError(t, err)
 	}
 }

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -142,7 +142,7 @@ func (p *Plugin) Subscribe(ctx context.Context, githubClient *github.Client, use
 	}
 
 	if flags.ExcludeOrgMembers && !p.isOrganizationLocked() {
-		return errors.Errorf("Unable to set --exclude-org-member flag. The GitHub plugin is not locked to a single organization.")
+		return errors.New("Unable to set --exclude-org-member flag. The GitHub plugin is not locked to a single organization.")
 	}
 
 	var err error

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -15,12 +15,14 @@ const mdCommentRegexPattern string = `(<!--[\S\s]+?-->)`
 
 // There is no public documentation of what constitutes a GitHub username, but
 // according to the error messages returned in https://github.com/join, it must:
-//   1. be between 1 and 39 characters long.
-//   2. contain only alphanumeric characters or non-adjacent hyphens.
-//   3. not begin or end with a hyphen.
+//  1. be between 1 and 39 characters long.
+//  2. contain only alphanumeric characters or non-adjacent hyphens.
+//  3. not begin or end with a hyphen.
+//
 // When matching a valid GitHub username in the body of messages, it must:
-//   4. not be preceded by an underscore, a backtick (that cryptic \x60) or an
-//      alphanumeric character.
+//  4. not be preceded by an underscore, a backtick (that cryptic \x60) or an
+//     alphanumeric character.
+//
 // Ensuring the maximum length is not trivial without lookaheads, so this
 // regexp ensures only the minimum length, besides points 2, 3 and 4.
 // Note that the username, with the @ sign, is in the second capturing group.


### PR DESCRIPTION
#### Summary
Fix linter errors caused by `golangci-lint` update

#### Ticket Link
None