### PR TITLE
keep telemetry init together and do the enable/disable thing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v41 v41.0.0
 	github.com/gorilla/mux v1.8.0
+	github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323124751-86c7be7ffbac
 	// mmgoget: github.com/mattermost/mattermost-server/v6@v7.5.0 is replaced by -> github.com/mattermost/mattermost-server/v6@21aec2741b
 	github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe
 	github.com/microcosm-cc/bluemonday v1.0.19
@@ -45,7 +46,6 @@ require (
 	github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 // indirect
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d // indirect
 	github.com/mattermost/logr/v2 v2.0.15 // indirect
-	github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323103040-f4c6bcdd4c83 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,10 @@ module github.com/mattermost/mattermost-plugin-github
 
 go 1.18
 
-// replace github.com/mattermost/mattermost-plugin-api => ../mattermost-plugin-api
-
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v41 v41.0.0
 	github.com/gorilla/mux v1.8.0
-	github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa
 	// mmgoget: github.com/mattermost/mattermost-server/v6@v7.5.0 is replaced by -> github.com/mattermost/mattermost-server/v6@21aec2741b
 	github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe
 	github.com/microcosm-cc/bluemonday v1.0.19
@@ -48,6 +45,7 @@ require (
 	github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 // indirect
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d // indirect
 	github.com/mattermost/logr/v2 v2.0.15 // indirect
+	github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323103040-f4c6bcdd4c83 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,13 @@ module github.com/mattermost/mattermost-plugin-github
 
 go 1.18
 
-replace github.com/mattermost/mattermost-plugin-api => ../mattermost-plugin-api
+// replace github.com/mattermost/mattermost-plugin-api => ../mattermost-plugin-api
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v41 v41.0.0
 	github.com/gorilla/mux v1.8.0
-	github.com/mattermost/mattermost-plugin-api v0.1.1
+	github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa
 	// mmgoget: github.com/mattermost/mattermost-server/v6@v7.5.0 is replaced by -> github.com/mattermost/mattermost-server/v6@21aec2741b
 	github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe
 	github.com/microcosm-cc/bluemonday v1.0.19

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/mattermost/mattermost-plugin-github
 
 go 1.18
 
+replace github.com/mattermost/mattermost-plugin-api => ../mattermost-plugin-api
+
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v41 v41.0.0

--- a/go.sum
+++ b/go.sum
@@ -231,12 +231,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3zBew=
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
-github.com/mattermost/mattermost-plugin-api v0.1.1 h1:bNnPbWCLWZpT/k2kjUxNnzCfUggU8WKs2ddz7hNjg1U=
-github.com/mattermost/mattermost-plugin-api v0.1.1/go.mod h1:9yZhtg0bBj3kqSTjXnjYBMZoTsWbe3ajdFMdl9/Jz34=
-github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa h1:KTTVmHJbkA6lwDTwg++YGJReuhYYJ9MDTHM8xXZ3rso=
-github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
-github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323103040-f4c6bcdd4c83 h1:YBY+/rcCSj05t0Lx1vfuBeUOC9KxVB78+BeY7mwsZaA=
-github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323103040-f4c6bcdd4c83/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
+github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323124751-86c7be7ffbac h1:fxdqYaw6wJfMSodMP0SNPm31r9kJ0NI8uQiWVpnj8F0=
+github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323124751-86c7be7ffbac/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe h1:9P759/e7xB3IQYo+6Ju9qsj3YUxpnPRXl2x+XFFsRIM=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe/go.mod h1:Eu6nct2XZRPlHHW4MfZtjli5bY7G9QomKcor/lm+0Sw=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/mattermost/mattermost-plugin-api v0.1.1 h1:bNnPbWCLWZpT/k2kjUxNnzCfUg
 github.com/mattermost/mattermost-plugin-api v0.1.1/go.mod h1:9yZhtg0bBj3kqSTjXnjYBMZoTsWbe3ajdFMdl9/Jz34=
 github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa h1:KTTVmHJbkA6lwDTwg++YGJReuhYYJ9MDTHM8xXZ3rso=
 github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
+github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323103040-f4c6bcdd4c83 h1:YBY+/rcCSj05t0Lx1vfuBeUOC9KxVB78+BeY7mwsZaA=
+github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230323103040-f4c6bcdd4c83/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe h1:9P759/e7xB3IQYo+6Ju9qsj3YUxpnPRXl2x+XFFsRIM=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe/go.mod h1:Eu6nct2XZRPlHHW4MfZtjli5bY7G9QomKcor/lm+0Sw=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
 github.com/mattermost/mattermost-plugin-api v0.1.1 h1:bNnPbWCLWZpT/k2kjUxNnzCfUggU8WKs2ddz7hNjg1U=
 github.com/mattermost/mattermost-plugin-api v0.1.1/go.mod h1:9yZhtg0bBj3kqSTjXnjYBMZoTsWbe3ajdFMdl9/Jz34=
+github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa h1:KTTVmHJbkA6lwDTwg++YGJReuhYYJ9MDTHM8xXZ3rso=
+github.com/mattermost/mattermost-plugin-api v0.1.3-0.20230322124503-df61c399c0aa/go.mod h1:EON5x6XoqubANT9zYLuL+m42SijzpK/dDOuu76PGbSc=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe h1:9P759/e7xB3IQYo+6Ju9qsj3YUxpnPRXl2x+XFFsRIM=
 github.com/mattermost/mattermost-server/v6 v6.0.0-20221109191448-21aec2741bfe/go.mod h1:Eu6nct2XZRPlHHW4MfZtjli5bY7G9QomKcor/lm+0Sw=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -408,6 +408,9 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 		return
 	}
 
+	// track the successful connection
+	p.tracker.TrackUserEvent("account_connected", c.UserID, nil)
+
 	userInfo := &GitHubUserInfo{
 		UserID:         state.UserID,
 		Token:          tok,

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -409,9 +409,7 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 	}
 
 	// track the successful connection
-	if err = p.tracker.TrackUserEvent("account_connected", c.UserID, nil); err != nil {
-		c.Log.WithError(err).Warnf("Failed to track telemetry 'account_connected' event")
-	}
+	p.TrackUserEvent("account_connected", c.UserID, nil)
 
 	userInfo := &GitHubUserInfo{
 		UserID:         state.UserID,

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -409,7 +409,9 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 	}
 
 	// track the successful connection
-	p.tracker.TrackUserEvent("account_connected", c.UserID, nil)
+	if err := p.tracker.TrackUserEvent("account_connected", c.UserID, nil); err != nil {
+		c.Log.WithError(err).Warnf("Failed to track telemetry 'account_connected' event")
+	}
 
 	userInfo := &GitHubUserInfo{
 		UserID:         state.UserID,

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -409,7 +409,7 @@ func (p *Plugin) completeConnectUserToGitHub(c *Context, w http.ResponseWriter, 
 	}
 
 	// track the successful connection
-	if err := p.tracker.TrackUserEvent("account_connected", c.UserID, nil); err != nil {
+	if err = p.tracker.TrackUserEvent("account_connected", c.UserID, nil); err != nil {
 		c.Log.WithError(err).Warnf("Failed to track telemetry 'account_connected' event")
 	}
 

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/mattermost/mattermost-plugin-api/experimental/telemetry"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
@@ -211,17 +212,9 @@ func (p *Plugin) OnConfigurationChange() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to register command")
 	}
-
-	enableDiagnostics := false
-	if config := p.API.GetConfig(); config != nil {
-		if configValue := config.LogSettings.EnableDiagnostics; configValue != nil {
-			enableDiagnostics = *configValue
-		}
-	}
-	if enableDiagnostics && p.tracker != nil {
-		p.tracker.Enable()
-	} else if !enableDiagnostics && p.tracker != nil {
-		p.tracker.Disable()
+	// Some config changes require reloading tracking config
+	if p.tracker != nil {
+		p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API))
 	}
 	return nil
 }

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/mattermost/mattermost-plugin-api/experimental/telemetry"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
@@ -219,9 +218,11 @@ func (p *Plugin) OnConfigurationChange() error {
 			enableDiagnostics = *configValue
 		}
 	}
-
-	p.tracker = telemetry.NewTracker(p.telemetryClient, p.API.GetDiagnosticId(), p.API.GetServerVersion(), Manifest.Id, Manifest.Version, "github", enableDiagnostics)
-
+	if enableDiagnostics && p.tracker != nil {
+		p.tracker.Enable()
+	} else if !enableDiagnostics && p.tracker != nil {
+		p.tracker.Disable()
+	}
 	return nil
 }
 

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -214,8 +214,9 @@ func (p *Plugin) OnConfigurationChange() error {
 	}
 	// Some config changes require reloading tracking config
 	if p.tracker != nil {
-		p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API))
+		p.tracker.ReloadConfig(telemetry.NewTrackerConfig(p.API.GetConfig()))
 	}
+
 	return nil
 }
 

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -278,7 +278,7 @@ func (p *Plugin) initializeTelemetry() {
 	// Telemetry client
 	p.telemetryClient, err = telemetry.NewRudderClient()
 	if err != nil {
-		p.API.LogWarn("Telemetry client not started", "error", err.Error())
+		p.API.LogWarn("Failed to start telemetry client", "error", err.Error())
 		return
 	}
 

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/go-github/v41/github"
 	"github.com/gorilla/mux"
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
-	"github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
 	"github.com/mattermost/mattermost-plugin-api/experimental/bot/poster"
 	"github.com/mattermost/mattermost-plugin-api/experimental/telemetry"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -266,45 +265,6 @@ func (p *Plugin) OnActivate() error {
 		}
 	}()
 	return nil
-}
-
-// Initialize telemetry setups the tracker/clients needed to send telemetry data.
-// - enable/disable is handled by LogSettings.EnableDiagnostics (also at onConfigurationChange for live changes)
-// - debug logging is added at pluginAPI side if ServiceSettings.EnableDeveloper is true
-func (p *Plugin) initializeTelemetry() {
-	var err error
-	var trackerLogger logger.Logger
-
-	// Telemetry client
-	p.telemetryClient, err = telemetry.NewRudderClient()
-	if err != nil {
-		p.API.LogWarn("Failed to start telemetry client", "error", err.Error())
-		return
-	}
-
-	// Get config values
-	enableDiagnostics := false
-	enableDeveloper := false
-	if config := p.API.GetConfig(); config != nil {
-		if configValue := config.LogSettings.EnableDiagnostics; configValue != nil {
-			enableDiagnostics = *configValue
-		}
-		if configValue := config.ServiceSettings.EnableDeveloper; configValue != nil {
-			enableDeveloper = *configValue
-		}
-	}
-	if enableDeveloper {
-		trackerLogger = logger.New(p.API)
-	}
-	p.tracker = telemetry.NewTracker(
-		p.telemetryClient,
-		p.API.GetDiagnosticId(),
-		p.API.GetServerVersion(),
-		Manifest.Id,
-		Manifest.Version,
-		"github",
-		enableDiagnostics,
-		trackerLogger)
 }
 
 func (p *Plugin) OnDeactivate() error {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-github/v41/github"
 	"github.com/gorilla/mux"
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
+	"github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
 	"github.com/mattermost/mattermost-plugin-api/experimental/bot/poster"
 	"github.com/mattermost/mattermost-plugin-api/experimental/telemetry"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -75,8 +76,7 @@ type Plugin struct {
 
 	router *mux.Router
 
-	telemetryClient telemetry.Client
-	tracker         telemetry.Tracker
+	tracker telemetry.Tracker
 
 	BotUserID   string
 	poster      poster.Poster
@@ -237,11 +237,7 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	p.initializeAPI()
-
-	p.telemetryClient, err = telemetry.NewRudderClient()
-	if err != nil {
-		p.API.LogWarn("Telemetry client not started", "error", err.Error())
-	}
+	p.initializeTelemetry()
 
 	p.webhookBroker = NewWebhookBroker(p.sendGitHubPingEvent)
 	p.oauthBroker = NewOAuthBroker(p.sendOAuthCompleteEvent)
@@ -269,6 +265,45 @@ func (p *Plugin) OnActivate() error {
 		}
 	}()
 	return nil
+}
+
+// Initialize telemetry setups the tracker/clients needed to send telemetry data.
+// - enable/disable is handled by LogSettings.EnableDiagnostics (also at onConfigurationChange for live changes)
+// - debug logging is added at pluginAPI side if ServiceSettings.EnableDeveloper is true
+func (p *Plugin) initializeTelemetry() {
+	var err error
+	var trackerLogger logger.Logger
+
+	// Telemetry client
+	telemetryClient, err := telemetry.NewRudderClient()
+	if err != nil {
+		p.API.LogWarn("Telemetry client not started", "error", err.Error())
+		return
+	}
+
+	// Get config values
+	enableDiagnostics := false
+	enableDeveloper := false
+	if config := p.API.GetConfig(); config != nil {
+		if configValue := config.LogSettings.EnableDiagnostics; configValue != nil {
+			enableDiagnostics = *configValue
+		}
+		if configValue := config.ServiceSettings.EnableDeveloper; configValue != nil {
+			enableDeveloper = *configValue
+		}
+	}
+	if enableDeveloper {
+		trackerLogger = logger.New(p.API)
+	}
+	p.tracker = telemetry.NewTracker(
+		telemetryClient,
+		p.API.GetDiagnosticId(),
+		p.API.GetServerVersion(),
+		Manifest.Id,
+		Manifest.Version,
+		"github",
+		enableDiagnostics,
+		trackerLogger)
 }
 
 func (p *Plugin) OnDeactivate() error {

--- a/server/plugin/telemetry.go
+++ b/server/plugin/telemetry.go
@@ -57,8 +57,8 @@ func (p *Plugin) getConnectedUserCount() (int64, error) {
 }
 
 // Initialize telemetry setups the tracker/clients needed to send telemetry data.
-// - enable/disable is handled by LogSettings.EnableDiagnostics (also at onConfigurationChange for live changes)
-// - debug logging is added at pluginAPI side if ServiceSettings.EnableDeveloper is true
+// The telemetry.NewTrackerConfig(...) param will take care of extract/parse the config to set rge right settings.
+// If you don't want the default behavior you still can pass a different telemetry.TrackerConfig data.
 func (p *Plugin) initializeTelemetry() {
 	var err error
 

--- a/server/plugin/telemetry.go
+++ b/server/plugin/telemetry.go
@@ -77,7 +77,7 @@ func (p *Plugin) initializeTelemetry() {
 		Manifest.Id,
 		Manifest.Version,
 		"github",
-		telemetry.NewTrackerConfig(p.API),
+		telemetry.NewTrackerConfig(p.API.GetConfig()),
 		logger.New(p.API),
 	)
 }


### PR DESCRIPTION
#### Summary

Requires https://github.com/mattermost/mattermost-plugin-api/pull/129 merge.
plugin-api version is hardcoded in the go.sum to the parent folder until we merge/release pluginapi (not expected to be merged as is).

It places telemetry client and tracker initialization together at onActivate and uses the new enable/disable commands at onConfigurationChange.

Also, pass a logger to the telemetry tracker when ServiceSettings.EnableDeveloper is true (through NewTelemetryTracker), which will end up logging the telemetry activity (no matter if the tracking config or client is disabled). This is still 2/5 until backwards-compatibility details are discussed.


Added event account_connected when we have a oauth successful connection (through setup or plain connect).

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-51400

