### PR TITLE
add e2e to lhs counters

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -157,7 +157,6 @@ jobs:
         env:
           PLUGIN_E2E_MOCK_OAUTH_TOKEN: ${{ secrets.MM_GITHUB_PLUGIN_E2E_TOKEN }}
           PW_BASE_URL: ${{ env.MM_SERVICESETTINGS_SITEURL }}
-          DEBUG: pw:api
 
       - name: ci/move-artifacts
         if: success() || failure()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -157,6 +157,7 @@ jobs:
         env:
           PLUGIN_E2E_MOCK_OAUTH_TOKEN: ${{ secrets.MM_GITHUB_PLUGIN_E2E_TOKEN }}
           PW_BASE_URL: ${{ env.MM_SERVICESETTINGS_SITEURL }}
+          DEBUG: pw:api
 
       - name: ci/move-artifacts
         if: success() || failure()

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -3,14 +3,13 @@
 # If there's no MM_RUDDER_PLUGINS_PROD, add DEV data
 RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
 ifdef MM_RUDDER_PLUGINS_PROD
-RUDDER_WRITE_KEY = $(MM_RUDDER_PLUGINS_PROD)
+	RUDDER_WRITE_KEY = $(MM_RUDDER_PLUGINS_PROD)
 endif
 
-GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(RUDDER_WRITE_KEY)"'
-
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(RUDDER_WRITE_KEY)"
 ifdef PLUGIN_E2E_MOCK_OAUTH_SERVER_URL
-	GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-github/server/plugin.testOAuthServerURL=$(PLUGIN_E2E_MOCK_OAUTH_SERVER_URL)"'
+	LDFLAGS +=  -X "github.com/mattermost/mattermost-plugin-github/server/plugin.testOAuthServerURL=$(PLUGIN_E2E_MOCK_OAUTH_SERVER_URL)"
 endif
-.PHONY: deploy-e2e
-deploy-e2e: dist
-	E2E_TESTING=true PLUGIN_E2E_MOCK_OAUTH_SERVER_URL=http://localhost:8080 ./build/bin/pluginctl deploy $(PLUGIN_ID) dist/$(BUNDLE_NAME)
+GO_BUILD_FLAGS = -ldflags '$(LDFLAGS)'
+
+

--- a/e2e/playwright/support/components/rhs.ts
+++ b/e2e/playwright/support/components/rhs.ts
@@ -17,7 +17,23 @@ export default class RHS {
         this.items = this.container.getByTestId('github-rhs-item');
     }
 
-    getItem(nth: number): Locator {
-        return this.items.nth(nth);
+    async getItem(nth: number) {
+        return new RHSItem(this.items.nth(nth));
+    }
+}
+
+export class RHSItem {
+    readonly header_title: Locator;
+    readonly title: Locator;
+    readonly id: Locator;
+    readonly repo: Locator;
+    readonly description: Locator;
+
+    constructor(readonly container: Locator) {
+        this.header_title = this.container.locator('.sidebar--right__title');
+        this.title = this.container.getByTestId('github-item-title');
+        this.id = this.container.getByTestId('github-item-id');
+        this.repo = this.container.getByTestId('github-item-repo');
+        this.description = this.container.getByTestId('github-item-description');
     }
 }

--- a/e2e/playwright/support/components/rhs.ts
+++ b/e2e/playwright/support/components/rhs.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Locator, Page} from '@playwright/test';
+
+export default class RHS {
+    readonly container: Locator;
+    readonly header_title: Locator;
+    readonly title: Locator;
+    readonly items: Locator;
+
+    constructor(readonly page: Page) {
+        this.page = page;
+        this.container = page.locator('#rhsContainer');
+        this.header_title = this.container.locator('.sidebar--right__title');
+        this.title = this.container.getByTestId('github-rhs-title').locator('a');
+        this.items = this.container.getByTestId('github-rhs-item');
+    }
+
+    getItem(nth: number): Locator {
+        return this.items.nth(nth);
+    }
+}

--- a/e2e/playwright/support/components/sidebar.ts
+++ b/e2e/playwright/support/components/sidebar.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Locator, Page} from '@playwright/test';
+
+import {GithubRHSCategory} from './todo_message';
+
+export default class Sidebar {
+    readonly counters: Map<GithubRHSCategory, Locator>;
+    readonly container: Locator;
+    readonly containerUnconnected: Locator;
+    readonly refresh: Locator;
+
+    constructor(readonly page: Page) {
+        this.page = page;
+        this.container = page.getByTestId('sidebar-github');
+        this.containerUnconnected = page.getByTestId('sidebar-github-unconnected');
+        this.refresh = this.container.getByTestId('sidebar-github-refresh');
+
+        this.counters = new Map<GithubRHSCategory, Locator>();
+        this.counters.set(GithubRHSCategory.UNREAD, this.container.getByTestId('sidebar-github-unreads'));
+        this.counters.set(GithubRHSCategory.OPEN_PR, this.container.getByTestId('sidebar-github-openpr'));
+        this.counters.set(GithubRHSCategory.REVIEW_PR, this.container.getByTestId('sidebar-github-reviewpr'));
+        this.counters.set(GithubRHSCategory.ASSIGNMENTS, this.container.getByTestId('sidebar-github-assignments'));
+    }
+
+    getCounter(kind: GithubRHSCategory): Locator {
+        return this.counters.get(kind) ?? this.container.locator('notfound');
+    }
+}

--- a/e2e/playwright/support/constants.ts
+++ b/e2e/playwright/support/constants.ts
@@ -9,10 +9,41 @@ export const messages = {
 };
 
 export const expectedData = {
-    [GithubRHSCategory.UNREAD]: '1',
-    [GithubRHSCategory.ASSIGNMENTS]: '32',
-    [GithubRHSCategory.REVIEW_PR]: '1',
-    [GithubRHSCategory.OPEN_PR]: '1',
+    [GithubRHSCategory.UNREAD]: {
+        count: '1',
+        firstItem: {
+            title: 'Update README.md',
+            link: 'https://github.com/MM-Github-Testorg/testrepo/issues/3#issuecomment-1485227142',
+            repo: 'MM-Github-Testorg/testrepo',
+            descriptionRegex: [/You were requested to review a pull request./, /days ago/],
+        }},
+    [GithubRHSCategory.ASSIGNMENTS]: {
+        count: '32',
+        firstItem: {
+            title: 'The title',
+            id: '#34',
+            link: 'https://github.com/MM-Github-Testorg/testrepo/issues/34',
+            repo: 'MM-Github-Testorg/testrepo',
+            descriptionRegex: [/Opened/, /days ago by MM-Github-Plugin/],
+        }},
+    [GithubRHSCategory.REVIEW_PR]: {
+        count: '1',
+        firstItem: {
+            title: 'Update README.md',
+            id: '#3',
+            link: 'https://github.com/MM-Github-Testorg/testrepo/pull/3',
+            repo: 'MM-Github-Testorg/testrepo',
+            descriptionRegex: [/Opened/, /days ago by trilopin/],
+        }},
+    [GithubRHSCategory.OPEN_PR]: {
+        count: '1',
+        firstItem: {
+            title: 'Update README.md',
+            id: '#1',
+            link: 'https://github.com/MM-Github-Testorg/testrepo/pull/1',
+            repo: 'MM-Github-Testorg/testrepo',
+            descriptionRegex: [/Opened/, /days ago by MM-Github-Plugin/],
+        }},
 };
 
 export const username = 'MM-Github-Plugin';

--- a/e2e/playwright/support/constants.ts
+++ b/e2e/playwright/support/constants.ts
@@ -10,7 +10,9 @@ export const messages = {
 
 export const expectedData = {
     [GithubRHSCategory.UNREAD]: '1',
-    [GithubRHSCategory.ASSIGNMENTS]: '19',
+    [GithubRHSCategory.ASSIGNMENTS]: '32',
     [GithubRHSCategory.REVIEW_PR]: '1',
     [GithubRHSCategory.OPEN_PR]: '1',
 };
+
+export const username = 'MM-Github-Plugin';

--- a/e2e/playwright/support/constants.ts
+++ b/e2e/playwright/support/constants.ts
@@ -1,7 +1,16 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {GithubRHSCategory} from './components/todo_message';
+
 export const messages = {
     UNCONNECTED: 'You must connect your account to GitHub first. Either click on the GitHub logo in the bottom left of the screen or enter /github connect.',
     NOSETUP: "Before using this plugin, you'll need to configure it by running /github setup: must have a github oauth client id",
+};
+
+export const expectedData = {
+    [GithubRHSCategory.UNREAD]: '1',
+    [GithubRHSCategory.ASSIGNMENTS]: '19',
+    [GithubRHSCategory.REVIEW_PR]: '1',
+    [GithubRHSCategory.OPEN_PR]: '1',
 };

--- a/e2e/playwright/support/user.ts
+++ b/e2e/playwright/support/user.ts
@@ -64,5 +64,11 @@ export const preferencesForUser = (userId: string) => {
             name: 'drafts_tour_tip_showed',
             value: '{"drafts_tour_tip_showed":true}',
         },
+        {
+            user_id: userId,
+            category: 'start_trial_modal',
+            name: 'trial_modal_auto_shown',
+            value: 'true',
+        },
     ];
 };

--- a/e2e/playwright/support/utils.ts
+++ b/e2e/playwright/support/utils.ts
@@ -37,9 +37,10 @@ export const postMessage = async (message: string, c: ChannelsPage, page: Page) 
     await page.getByTestId('SendMessageButton').click();
 };
 
-export const clickPostAction = async (name: string, c: ChannelsPage) => {
+export const clickPostAction = async (name: string, c: ChannelsPage, page: Page) => {
     // We need to wait for the next post to come up, since this opening a new tab and OAuth redirect can take an undeterminate
     // https://mattermost.atlassian.net/browse/MM-51906
+    await page.waitForTimeout(500);
     const postElement = await c.getLastPost();
     await postElement.container.getByText(name).last().click();
 };

--- a/e2e/playwright/tests/command/me.spec.ts
+++ b/e2e/playwright/tests/command/me.spec.ts
@@ -8,14 +8,12 @@
 
 import {expect, test} from '@e2e-support/test_fixture';
 
-import {messages} from '../../support/constants';
+import {messages, username} from '../../support/constants';
 import {getGithubBotDMPageURL, waitForNewMessages} from '../../support/utils';
 import {
     getBotTagFromPost,
     getPostAuthor,
 } from '../../support/components/post';
-
-const mmGithubHandle = 'MM-Github-Plugin';
 
 export default {
     connected: () => {
@@ -50,7 +48,7 @@ export default {
                 await expect(post.container.getByText('You are connected to Github as')).toBeVisible();
 
                 // * check username
-                await expect(post.container.getByRole('link', {name: mmGithubHandle})).toBeVisible();
+                await expect(post.container.getByRole('link', {name: username})).toBeVisible();
 
                 // * check profile image
                 await expect(post.container.getByRole('heading').locator('img')).toBeVisible();

--- a/e2e/playwright/tests/command/todo.spec.ts
+++ b/e2e/playwright/tests/command/todo.spec.ts
@@ -53,14 +53,14 @@ export default {
                 // * Assert that description are there for each section
                 // Singular/plurals are not taken into account: ticket separated at https://mattermost.atlassian.net/browse/MM-52416
                 // Counters may vary and should be explicitely changed once the test accounts are set
-                await expect(todo.getDesc(GithubRHSCategory.OPEN_PR)).toHaveText(`You have ${expectedData[GithubRHSCategory.OPEN_PR]} open pull requests:`);
-                await expect(todo.getDesc(GithubRHSCategory.ASSIGNMENTS)).toHaveText(`You have ${expectedData[GithubRHSCategory.ASSIGNMENTS]} assignments:`);
-                await expect(todo.getDesc(GithubRHSCategory.REVIEW_PR)).toHaveText(`You have ${expectedData[GithubRHSCategory.REVIEW_PR]} pull requests awaiting your review:`);
-                await expect(todo.getDesc(GithubRHSCategory.UNREAD)).toHaveText(`You have ${expectedData[GithubRHSCategory.UNREAD]} unread messages:`);
+                await expect(todo.getDesc(GithubRHSCategory.OPEN_PR)).toHaveText(`You have ${expectedData[GithubRHSCategory.OPEN_PR].count} open pull requests:`);
+                await expect(todo.getDesc(GithubRHSCategory.ASSIGNMENTS)).toHaveText(`You have ${expectedData[GithubRHSCategory.ASSIGNMENTS].count} assignments:`);
+                await expect(todo.getDesc(GithubRHSCategory.REVIEW_PR)).toHaveText(`You have ${expectedData[GithubRHSCategory.REVIEW_PR].count} pull requests awaiting your review:`);
+                await expect(todo.getDesc(GithubRHSCategory.UNREAD)).toHaveText(`You have ${expectedData[GithubRHSCategory.UNREAD].count} unread messages:`);
 
                 // * Assert the open pull request list has 1 items
                 const openPr = await todo.getList(GithubRHSCategory.OPEN_PR);
-                await expect(openPr.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.OPEN_PR]));
+                await expect(openPr.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.OPEN_PR].count));
 
                 // * Assert the open pull request links are correct <REPO> <PR>
                 await expect(openPr.locator('li').nth(0).locator('a').nth(0)).toHaveAttribute('href', repoRegex);
@@ -68,7 +68,7 @@ export default {
 
                 // * Assert the review request list has 1 items
                 const reviewPr = await todo.getList(GithubRHSCategory.REVIEW_PR);
-                await expect(reviewPr.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.REVIEW_PR]));
+                await expect(reviewPr.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.REVIEW_PR].count));
 
                 // * Assert the pull request links are correct <REPO> <PR>
                 await expect(reviewPr.locator('li').nth(0).locator('a').nth(0)).toHaveAttribute('href', repoRegex);
@@ -76,7 +76,7 @@ export default {
 
                 // * Assert the assignments list has 1 items
                 const assignments = await todo.getList(GithubRHSCategory.ASSIGNMENTS);
-                await expect(assignments.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.ASSIGNMENTS]));
+                await expect(assignments.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.ASSIGNMENTS].count));
 
                 // * Assert the assignments links are correct <REPO> <ISSUE>
                 await expect(assignments.locator('li').nth(0).locator('a').nth(0)).toHaveAttribute('href', repoRegex);
@@ -84,7 +84,7 @@ export default {
 
                 // * Assert the unread has 1 items
                 const unread = await todo.getList(GithubRHSCategory.UNREAD);
-                await expect(unread.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.UNREAD]));
+                await expect(unread.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.UNREAD].count));
 
                 // # Refresh
                 await page.reload();

--- a/e2e/playwright/tests/command/todo.spec.ts
+++ b/e2e/playwright/tests/command/todo.spec.ts
@@ -8,7 +8,7 @@
 import {test, expect} from '@e2e-support/test_fixture';
 
 import TodoMessage, {GithubRHSCategory} from '../../support/components/todo_message';
-import {messages} from '../../support/constants';
+import {messages, expectedData} from '../../support/constants';
 import {getGithubBotDMPageURL, waitForNewMessages} from '../../support/utils';
 import {getBotTagFromPost, getPostAuthor} from '../../support/components/post';
 
@@ -53,14 +53,14 @@ export default {
                 // * Assert that description are there for each section
                 // Singular/plurals are not taken into account: ticket separated at https://mattermost.atlassian.net/browse/MM-52416
                 // Counters may vary and should be explicitely changed once the test accounts are set
-                await expect(todo.getDesc(GithubRHSCategory.OPEN_PR)).toHaveText('You have 1 open pull requests:');
-                await expect(todo.getDesc(GithubRHSCategory.ASSIGNMENTS)).toHaveText('You have 19 assignments:');
-                await expect(todo.getDesc(GithubRHSCategory.REVIEW_PR)).toHaveText('You have 1 pull requests awaiting your review:');
-                await expect(todo.getDesc(GithubRHSCategory.UNREAD)).toHaveText('You have 1 unread messages:');
+                await expect(todo.getDesc(GithubRHSCategory.OPEN_PR)).toHaveText(`You have ${expectedData[GithubRHSCategory.OPEN_PR]} open pull requests:`);
+                await expect(todo.getDesc(GithubRHSCategory.ASSIGNMENTS)).toHaveText(`You have ${expectedData[GithubRHSCategory.ASSIGNMENTS]} assignments:`);
+                await expect(todo.getDesc(GithubRHSCategory.REVIEW_PR)).toHaveText(`You have ${expectedData[GithubRHSCategory.REVIEW_PR]} pull requests awaiting your review:`);
+                await expect(todo.getDesc(GithubRHSCategory.UNREAD)).toHaveText(`You have ${expectedData[GithubRHSCategory.UNREAD]} unread messages:`);
 
                 // * Assert the open pull request list has 1 items
                 const openPr = await todo.getList(GithubRHSCategory.OPEN_PR);
-                await expect(openPr.locator('li')).toHaveCount(1);
+                await expect(openPr.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.OPEN_PR]));
 
                 // * Assert the open pull request links are correct <REPO> <PR>
                 await expect(openPr.locator('li').nth(0).locator('a').nth(0)).toHaveAttribute('href', repoRegex);
@@ -68,7 +68,7 @@ export default {
 
                 // * Assert the review request list has 1 items
                 const reviewPr = await todo.getList(GithubRHSCategory.REVIEW_PR);
-                await expect(reviewPr.locator('li')).toHaveCount(1);
+                await expect(reviewPr.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.REVIEW_PR]));
 
                 // * Assert the pull request links are correct <REPO> <PR>
                 await expect(reviewPr.locator('li').nth(0).locator('a').nth(0)).toHaveAttribute('href', repoRegex);
@@ -76,7 +76,7 @@ export default {
 
                 // * Assert the assignments list has 1 items
                 const assignments = await todo.getList(GithubRHSCategory.ASSIGNMENTS);
-                await expect(assignments.locator('li')).toHaveCount(19);
+                await expect(assignments.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.ASSIGNMENTS]));
 
                 // * Assert the assignments links are correct <REPO> <ISSUE>
                 await expect(assignments.locator('li').nth(0).locator('a').nth(0)).toHaveAttribute('href', repoRegex);
@@ -84,7 +84,7 @@ export default {
 
                 // * Assert the unread has 1 items
                 const unread = await todo.getList(GithubRHSCategory.UNREAD);
-                await expect(unread.locator('li')).toHaveCount(1);
+                await expect(unread.locator('li')).toHaveCount(Number(expectedData[GithubRHSCategory.UNREAD]));
 
                 // # Refresh
                 await page.reload();

--- a/e2e/playwright/tests/github_plugin.spec.ts
+++ b/e2e/playwright/tests/github_plugin.spec.ts
@@ -30,16 +30,12 @@ export default {
             // # Run setup command
             await postMessage('/github setup', c, page);
 
-            // # Wait for new messages to ensure the last post is the one we want
-            // await waitForNewMessages(page);
-            await page.waitForTimeout(1000);
-
             // # Go through prompts of setup flow
-            await clickPostAction('Continue', c);
-            await clickPostAction("I'll do it myself", c);
-            await clickPostAction('No', c);
-            await clickPostAction('Continue', c);
-            await clickPostAction('Continue', c);
+            await clickPostAction('Continue', c, page);
+            await clickPostAction("I'll do it myself", c, page);
+            await clickPostAction('No', c, page);
+            await clickPostAction('Continue', c, page);
+            await clickPostAction('Continue', c, page);
 
             // # Fill out interactive dialog for GitHub client id and client secret
             await fillTextField('client_id', TEST_CLIENT_ID, page);
@@ -65,10 +61,10 @@ export default {
             await page.click(connectLinkLocator);
 
             // # Say no to "Create a webhook"
-            await clickPostAction('No', c);
+            await clickPostAction('No', c, page);
 
             // # Say no to "Broadcast to channel"
-            await clickPostAction('Not now', c);
+            await clickPostAction('Not now', c, page);
         });
     },
     connect: () => {

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -37,4 +37,3 @@ test.describe(core.disconnect);
 test.describe(me.unconnected);
 test.describe(todo.unconnected);
 test.describe(autocomplete.unconnected);
-test.describe(sidebar.unconnected);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -13,29 +13,29 @@ import rhs from './ui/rhs.spec';
 import '../support/init_test';
 
 // Test features when no setup is done
-test.describe(autocomplete.noSetup);
-test.describe(me.noSetup);
-test.describe(todo.noSetup);
+// test.describe(autocomplete.noSetup);
+// test.describe(me.noSetup);
+// test.describe(todo.noSetup);
 test.describe(sidebar.noSetup);
 
-// Test /github setup
-test.describe(core.setup);
+// // Test /github setup
+// test.describe(core.setup);
 
-// Test /github connect
-test.describe(core.connect);
+// // Test /github connect
+// test.describe(core.connect);
 
-// Test features that needs connect
-test.describe(autocomplete.connected);
-test.describe(me.connected);
-test.describe(todo.connected);
-test.describe(sidebar.connected);
-test.describe(rhs.connected);
+// // Test features that needs connect
+// test.describe(autocomplete.connected);
+// test.describe(me.connected);
+// test.describe(todo.connected);
+// test.describe(sidebar.connected);
+// test.describe(rhs.connected);
 
-// Test /github disconnect
-test.describe(core.disconnect);
+// // Test /github disconnect
+// test.describe(core.disconnect);
 
-// Test features when setup but no conection
-test.describe(me.unconnected);
-test.describe(todo.unconnected);
-test.describe(autocomplete.unconnected);
-test.describe(sidebar.unconnected);
+// // Test features when setup but no conection
+// test.describe(me.unconnected);
+// test.describe(todo.unconnected);
+// test.describe(autocomplete.unconnected);
+// test.describe(sidebar.unconnected);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -13,29 +13,28 @@ import rhs from './ui/rhs.spec';
 import '../support/init_test';
 
 // Test features when no setup is done
-// test.describe(autocomplete.noSetup);
-// test.describe(me.noSetup);
-// test.describe(todo.noSetup);
-test.describe(sidebar.noSetup);
+test.describe(autocomplete.noSetup);
+test.describe(me.noSetup);
+test.describe(todo.noSetup);
 
-// // Test /github setup
-// test.describe(core.setup);
+// Test /github setup
+test.describe(core.setup);
 
-// // Test /github connect
-// test.describe(core.connect);
+// Test /github connect
+test.describe(core.connect);
 
-// // Test features that needs connect
-// test.describe(autocomplete.connected);
-// test.describe(me.connected);
-// test.describe(todo.connected);
-// test.describe(sidebar.connected);
-// test.describe(rhs.connected);
+// Test features that needs connect
+test.describe(autocomplete.connected);
+test.describe(me.connected);
+test.describe(todo.connected);
+test.describe(sidebar.connected);
+test.describe(rhs.connected);
 
-// // Test /github disconnect
-// test.describe(core.disconnect);
+// Test /github disconnect
+test.describe(core.disconnect);
 
-// // Test features when setup but no conection
-// test.describe(me.unconnected);
-// test.describe(todo.unconnected);
-// test.describe(autocomplete.unconnected);
-// test.describe(sidebar.unconnected);
+// Test features when setup but no conection
+test.describe(me.unconnected);
+test.describe(todo.unconnected);
+test.describe(autocomplete.unconnected);
+test.describe(sidebar.unconnected);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -7,6 +7,8 @@ import core from './github_plugin.spec';
 import me from './command/me.spec';
 import todo from './command/todo.spec';
 import autocomplete from './command/autocomplete.spec';
+import sidebar from './ui/sidebar.spec';
+import rhs from './ui/rhs.spec';
 
 import '../support/init_test';
 
@@ -14,6 +16,9 @@ import '../support/init_test';
 test.describe(autocomplete.noSetup);
 test.describe(me.noSetup);
 test.describe(todo.noSetup);
+test.describe(sidebar.noSetup);
+
+// test.describe(rhs.noSetup);
 
 // Test /github setup
 test.describe(core.setup);
@@ -25,6 +30,9 @@ test.describe(core.connect);
 test.describe(autocomplete.connected);
 test.describe(me.connected);
 test.describe(todo.connected);
+test.describe(sidebar.connected);
+
+// test.describe(rhs.connected);
 
 // Test /github disconnect
 test.describe(core.disconnect);
@@ -33,3 +41,6 @@ test.describe(core.disconnect);
 test.describe(me.unconnected);
 test.describe(todo.unconnected);
 test.describe(autocomplete.unconnected);
+test.describe(sidebar.unconnected);
+
+// test.describe(rhs.unconnected);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -18,8 +18,6 @@ test.describe(me.noSetup);
 test.describe(todo.noSetup);
 test.describe(sidebar.noSetup);
 
-// test.describe(rhs.noSetup);
-
 // Test /github setup
 test.describe(core.setup);
 
@@ -31,8 +29,7 @@ test.describe(autocomplete.connected);
 test.describe(me.connected);
 test.describe(todo.connected);
 test.describe(sidebar.connected);
-
-// test.describe(rhs.connected);
+test.describe(rhs.connected);
 
 // Test /github disconnect
 test.describe(core.disconnect);
@@ -42,5 +39,3 @@ test.describe(me.unconnected);
 test.describe(todo.unconnected);
 test.describe(autocomplete.unconnected);
 test.describe(sidebar.unconnected);
-
-// test.describe(rhs.unconnected);

--- a/e2e/playwright/tests/ui/rhs.spec.ts
+++ b/e2e/playwright/tests/ui/rhs.spec.ts
@@ -51,7 +51,32 @@ export default {
                 await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
 
                 // * Assert RHS item count is correct
-                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.OPEN_PR]));
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.OPEN_PR].count));
+
+                // # Get first item
+                const item = await rhs.getItem(0);
+                const expectedItem = expectedData[GithubRHSCategory.OPEN_PR].firstItem;
+
+                // * Assert Title / Link
+                await expect(item.title).toHaveText(expectedItem.title);
+                await expect(item.title).toHaveAttribute('href', expectedItem.link);
+                await expect(item.title).toHaveAttribute('target', '_blank');
+                await expect(item.title).toBeEnabled();
+
+                // * Assert ID
+                await expect(item.id).toHaveText(expectedItem.id);
+                await expect(item.id).toHaveAttribute('href', expectedItem.link);
+                await expect(item.id).toHaveAttribute('target', '_blank');
+                await expect(item.id).toBeEnabled();
+
+                // * Assert Repository
+                await expect(item.repo).toHaveText(`(${expectedItem.repo})`);
+
+                // * Assert Description
+                for (const r of expectedItem.descriptionRegex) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await expect(item.description).toHaveText(r);
+                }
             });
 
             test('Your review PRs', async ({page, pw}) => {
@@ -88,7 +113,32 @@ export default {
                 await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
 
                 // * Assert RHS item count is correct
-                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.REVIEW_PR]));
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.REVIEW_PR].count));
+
+                // # Get first item
+                const item = await rhs.getItem(0);
+                const expectedItem = expectedData[GithubRHSCategory.REVIEW_PR].firstItem;
+
+                // * Assert Title / Link
+                await expect(item.title).toHaveText(expectedItem.title);
+                await expect(item.title).toHaveAttribute('href', expectedItem.link);
+                await expect(item.title).toHaveAttribute('target', '_blank');
+                await expect(item.title).toBeEnabled();
+
+                // * Assert ID
+                await expect(item.id).toHaveText(expectedItem.id);
+                await expect(item.id).toHaveAttribute('href', expectedItem.link);
+                await expect(item.id).toHaveAttribute('target', '_blank');
+                await expect(item.id).toBeEnabled();
+
+                // * Assert Repository
+                await expect(item.repo).toHaveText(`(${expectedItem.repo})`);
+
+                // * Assert Description
+                for (const r of expectedItem.descriptionRegex) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await expect(item.description).toHaveText(r);
+                }
             });
 
             test('Your assignments', async ({page, pw}) => {
@@ -125,7 +175,31 @@ export default {
                 await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
 
                 // * Assert RHS item count is correct
-                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.ASSIGNMENTS]));
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.ASSIGNMENTS].count));
+
+                const item = await rhs.getItem(0);
+                const expectedItem = expectedData[GithubRHSCategory.ASSIGNMENTS].firstItem;
+
+                // * Assert Title / Link
+                await expect(item.title).toHaveText(expectedItem.title);
+                await expect(item.title).toHaveAttribute('href', expectedItem.link);
+                await expect(item.title).toHaveAttribute('target', '_blank');
+                await expect(item.title).toBeEnabled();
+
+                // * Assert ID
+                await expect(item.id).toHaveText(expectedItem.id);
+                await expect(item.id).toHaveAttribute('href', expectedItem.link);
+                await expect(item.id).toHaveAttribute('target', '_blank');
+                await expect(item.id).toBeEnabled();
+
+                // * Assert Repository
+                await expect(item.repo).toHaveText(`(${expectedItem.repo})`);
+
+                // * Assert Description
+                for (const r of expectedItem.descriptionRegex) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await expect(item.description).toHaveText(r);
+                }
             });
 
             test('Unread notifications', async ({page, pw}) => {
@@ -162,7 +236,28 @@ export default {
                 await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
 
                 // * Assert RHS item count is correct
-                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.UNREAD]));
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.UNREAD].count));
+
+                const item = await rhs.getItem(0);
+                const expectedItem = expectedData[GithubRHSCategory.UNREAD].firstItem;
+
+                // * Assert Title / Link
+                await expect(item.title).toHaveText(expectedItem.title);
+                await expect(item.title).toHaveAttribute('href', expectedItem.link);
+                await expect(item.title).toHaveAttribute('target', '_blank');
+                await expect(item.title).toBeEnabled();
+
+                // * Assert ID does not exist
+                await expect(item.id).not.toBeVisible();
+
+                // * Assert Repository
+                await expect(item.repo).toHaveText(`(${expectedItem.repo})`);
+
+                // * Assert Description
+                for (const r of expectedItem.descriptionRegex) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await expect(item.description).toHaveText(r);
+                }
             });
         });
     },

--- a/e2e/playwright/tests/ui/rhs.spec.ts
+++ b/e2e/playwright/tests/ui/rhs.spec.ts
@@ -8,44 +8,161 @@
 
 import {expect, test} from '@e2e-support/test_fixture';
 
-import {messages} from '../../support/constants';
-import {getGithubBotDMPageURL, waitForNewMessages} from '../../support/utils';
-import {
-    getBotTagFromPost,
-    getPostAuthor,
-} from '../../support/components/post';
+import {GithubRHSCategory} from '../../support/components/todo_message';
+import RHS from '../../support/components/rhs';
+import Sidebar from '../../support/components/sidebar';
+import {expectedData, username} from '../../support/constants';
+import {getGithubBotDMPageURL} from '../../support/utils';
 
 export default {
     connected: () => {
         test.describe('RHS panel', () => {
-            test('from connected account', async ({pages, page, pw}) => {
+            test('Your open PRs', async ({page, pw}) => {
                 const {adminClient, adminUser} = await pw.getAdminClient();
                 if (adminUser === null) {
                     throw new Error('can not get adminUser');
                 }
-            });
-        });
-    },
-    unconnected: () => {
-        test.describe('RHS panel', () => {
-            test('from non connected account', async ({pages, page, pw}) => {
-                const {adminClient, adminUser} = await pw.getAdminClient();
-                if (adminUser === null) {
-                    throw new Error('can not get adminUser');
-                }
-
                 const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
                 await page.goto(dmURL, {waitUntil: 'load'});
+
+                const sidebar = new Sidebar(page);
+                const rhs = new RHS(page);
+
+                await sidebar.refresh.click();
+                await page.waitForTimeout(1000);
+
+                // # Click on Open PRs icon at sidebar
+                await sidebar.getCounter(GithubRHSCategory.OPEN_PR).click();
+
+                // * RHS must be visible
+                await expect(rhs.container).toBeVisible();
+
+                // * Assert RHS title is GitHub
+                await expect(rhs.header_title).toHaveText('GitHub');
+
+                // * Assert RHS subtitle text is correct
+                await expect(rhs.title).toHaveText('Your Open Pull Requests');
+
+                // * Assert RHS subtitle link is correct
+                await expect(rhs.title).toBeVisible();
+                await expect(rhs.title).toBeEnabled();
+                await expect(rhs.title).toHaveAttribute('href', `https://github.com/pulls?q=is%3Aopen+is%3Apr+author%3A${username}+archived%3Afalse`);
+                await expect(rhs.title).toHaveAttribute('target', '_blank');
+                await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
+
+                // * Assert RHS item count is correct
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.OPEN_PR]));
             });
-        });
-    },
-    noSetup: () => {
-        test.describe('RHS panel', () => {
-            test('before doing setup', async ({pages, page, pw}) => {
+
+            test('Your review PRs', async ({page, pw}) => {
                 const {adminClient, adminUser} = await pw.getAdminClient();
                 if (adminUser === null) {
                     throw new Error('can not get adminUser');
                 }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                const sidebar = new Sidebar(page);
+                const rhs = new RHS(page);
+
+                await sidebar.refresh.click();
+                await page.waitForTimeout(1000);
+
+                // # Click on Open PRs icon at sidebar
+                await sidebar.getCounter(GithubRHSCategory.REVIEW_PR).click();
+
+                // * RHS must be visible
+                await expect(rhs.container).toBeVisible();
+
+                // * Assert RHS title is GitHub
+                await expect(rhs.header_title).toHaveText('GitHub');
+
+                // * Assert RHS subtitle text is correct
+                await expect(rhs.title).toHaveText('Pull Requests Needing Review');
+
+                // * Assert RHS subtitle link is correct
+                await expect(rhs.title).toBeVisible();
+                await expect(rhs.title).toBeEnabled();
+                await expect(rhs.title).toHaveAttribute('href', `https://github.com/pulls?q=is%3Aopen+is%3Apr+review-requested%3A${username}+archived%3Afalse`);
+                await expect(rhs.title).toHaveAttribute('target', '_blank');
+                await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
+
+                // * Assert RHS item count is correct
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.REVIEW_PR]));
+            });
+
+            test('Your assignments', async ({page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                const sidebar = new Sidebar(page);
+                const rhs = new RHS(page);
+
+                await sidebar.refresh.click();
+                await page.waitForTimeout(1000);
+
+                // # Click on Open PRs icon at sidebar
+                await sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS).click();
+
+                // * RHS must be visible
+                await expect(rhs.container).toBeVisible();
+
+                // * Assert RHS title is GitHub
+                await expect(rhs.header_title).toHaveText('GitHub');
+
+                // * Assert RHS subtitle text is correct
+                await expect(rhs.title).toHaveText('Your Assignments');
+
+                // * Assert RHS subtitle link is correct
+                await expect(rhs.title).toBeVisible();
+                await expect(rhs.title).toBeEnabled();
+                await expect(rhs.title).toHaveAttribute('href', `https://github.com/pulls?q=is%3Aopen+archived%3Afalse+assignee%3A${username}`);
+                await expect(rhs.title).toHaveAttribute('target', '_blank');
+                await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
+
+                // * Assert RHS item count is correct
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.ASSIGNMENTS]));
+            });
+
+            test('Unread notifications', async ({page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                const sidebar = new Sidebar(page);
+                const rhs = new RHS(page);
+
+                await sidebar.refresh.click();
+                await page.waitForTimeout(1000);
+
+                // # Click on Open PRs icon at sidebar
+                await sidebar.getCounter(GithubRHSCategory.UNREAD).click();
+
+                // * RHS must be visible
+                await expect(rhs.container).toBeVisible();
+
+                // * Assert RHS title is GitHub
+                await expect(rhs.header_title).toHaveText('GitHub');
+
+                // * Assert RHS subtitle text is correct
+                await expect(rhs.title).toHaveText('Unread Messages');
+
+                // * Assert RHS subtitle link is correct
+                await expect(rhs.title).toBeVisible();
+                await expect(rhs.title).toBeEnabled();
+                await expect(rhs.title).toHaveAttribute('href', 'https://github.com/notifications');
+                await expect(rhs.title).toHaveAttribute('target', '_blank');
+                await expect(rhs.title).toHaveAttribute('rel', 'noopener noreferrer');
+
+                // * Assert RHS item count is correct
+                await expect(rhs.items).toHaveCount(Number(expectedData[GithubRHSCategory.UNREAD]));
             });
         });
     },

--- a/e2e/playwright/tests/ui/rhs.spec.ts
+++ b/e2e/playwright/tests/ui/rhs.spec.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+import {expect, test} from '@e2e-support/test_fixture';
+
+import {messages} from '../../support/constants';
+import {getGithubBotDMPageURL, waitForNewMessages} from '../../support/utils';
+import {
+    getBotTagFromPost,
+    getPostAuthor,
+} from '../../support/components/post';
+
+export default {
+    connected: () => {
+        test.describe('RHS panel', () => {
+            test('from connected account', async ({pages, page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+            });
+        });
+    },
+    unconnected: () => {
+        test.describe('RHS panel', () => {
+            test('from non connected account', async ({pages, page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+            });
+        });
+    },
+    noSetup: () => {
+        test.describe('RHS panel', () => {
+            test('before doing setup', async ({pages, page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+            });
+        });
+    },
+};

--- a/e2e/playwright/tests/ui/sidebar.spec.ts
+++ b/e2e/playwright/tests/ui/sidebar.spec.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+import {expect, test} from '@e2e-support/test_fixture';
+
+import {GithubRHSCategory} from '../../support/components/todo_message';
+import {expectedData} from '../../support/constants';
+import {getGithubBotDMPageURL} from '../../support/utils';
+
+export default {
+    connected: () => {
+        test.describe('left sidebar', () => {
+            test('from connected account (before refresh)', async ({page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                // * Unconnected version of icon shouldn't be visible
+                await expect(page.getByTestId('sidebar-github-unconnected')).not.toBeVisible();
+
+                // * Counters must be visible
+                await expect(page.getByTestId('sidebar-github')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-openpr')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-reviewpr')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-assignments')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-unreads')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-refresh')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-refresh')).toBeEnabled();
+
+                // * Assert counters before refresh
+                await expect(page.getByTestId('sidebar-github-openpr')).toHaveText('0');
+                await expect(page.getByTestId('sidebar-github-reviewpr')).toHaveText('0');
+                await expect(page.getByTestId('sidebar-github-assignments')).toHaveText('0');
+                await expect(page.getByTestId('sidebar-github-unreads')).toHaveText('0');
+            });
+
+            test('from connected account (after refresh)', async ({page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                // * Unconnected version of icon shouldn't be visible
+                await expect(page.getByTestId('sidebar-github-unconnected')).not.toBeVisible();
+
+                // # Click refresh data (fetch, impacts rate limit)
+                await page.getByTestId('sidebar-github-refresh').click();
+
+                // # Waits for 1sec
+                await page.waitForTimeout(1000);
+
+                // * Counters must be visible
+                await expect(page.getByTestId('sidebar-github')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-openpr')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-reviewpr')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-assignments')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-unreads')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-refresh')).toBeVisible();
+                await expect(page.getByTestId('sidebar-github-refresh')).toBeEnabled();
+
+                // * Assert counters before refresh
+                await expect(page.getByTestId('sidebar-github-openpr')).toHaveText(expectedData[GithubRHSCategory.OPEN_PR]);
+                await expect(page.getByTestId('sidebar-github-reviewpr')).toHaveText(expectedData[GithubRHSCategory.REVIEW_PR]);
+                await expect(page.getByTestId('sidebar-github-assignments')).toHaveText(expectedData[GithubRHSCategory.ASSIGNMENTS]);
+                await expect(page.getByTestId('sidebar-github-unreads')).toHaveText(expectedData[GithubRHSCategory.UNREAD]);
+            });
+        });
+    },
+    unconnected: () => {
+        test.describe('left sidebar', () => {
+            test('from non connected account', async ({page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                // * Unconnected version of icon should be visible
+                await expect(page.getByTestId('sidebar-github-unconnected')).toBeVisible();
+
+                // * Unconnected version of icon should have the connect link
+                await expect(page.getByTestId('sidebar-github-unconnected')).toHaveAttribute('href', '/plugins/github/oauth/connect');
+            });
+        });
+    },
+    noSetup: () => {
+        test.describe('left sidebar', () => {
+            test('before doing setup', async ({page, pw}) => {
+                const {adminClient, adminUser} = await pw.getAdminClient();
+                if (adminUser === null) {
+                    throw new Error('can not get adminUser');
+                }
+                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
+                await page.goto(dmURL, {waitUntil: 'load'});
+
+                // * Unconnected version of icon should be visible
+                await expect(page.getByTestId('sidebar-github-unconnected')).toBeVisible();
+
+                // * Unconnected version of icon should have the connect link
+                await expect(page.getByTestId('sidebar-github-unconnected')).toHaveAttribute('href', '/plugins/github/oauth/connect');
+            });
+        });
+    },
+};

--- a/e2e/playwright/tests/ui/sidebar.spec.ts
+++ b/e2e/playwright/tests/ui/sidebar.spec.ts
@@ -74,50 +74,10 @@ export default {
                 await expect(sidebar.refresh).toBeEnabled();
 
                 // * Assert counters before refresh
-                await expect(sidebar.getCounter(GithubRHSCategory.OPEN_PR)).toHaveText(expectedData[GithubRHSCategory.OPEN_PR]);
-                await expect(sidebar.getCounter(GithubRHSCategory.REVIEW_PR)).toHaveText(expectedData[GithubRHSCategory.REVIEW_PR]);
-                await expect(sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS)).toHaveText(expectedData[GithubRHSCategory.ASSIGNMENTS]);
-                await expect(sidebar.getCounter(GithubRHSCategory.UNREAD)).toHaveText(expectedData[GithubRHSCategory.UNREAD]);
-            });
-        });
-    },
-    unconnected: () => {
-        test.describe('left sidebar', () => {
-            test('from non connected account', async ({page, pw}) => {
-                const {adminClient, adminUser} = await pw.getAdminClient();
-                if (adminUser === null) {
-                    throw new Error('can not get adminUser');
-                }
-                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
-                await page.goto(dmURL, {waitUntil: 'load'});
-
-                const sidebar = new Sidebar(page);
-
-                // * Unconnected version of icon should be visible
-                await expect(sidebar.containerUnconnected).toBeVisible();
-
-                // * Unconnected version of icon should have the connect link
-                await expect(sidebar.containerUnconnected).toHaveAttribute('href', '/plugins/github/oauth/connect');
-            });
-        });
-    },
-    noSetup: () => {
-        test.describe('left sidebar', () => {
-            test('before doing setup', async ({page, pw}) => {
-                const {adminClient, adminUser} = await pw.getAdminClient();
-                if (adminUser === null) {
-                    throw new Error('can not get adminUser');
-                }
-                const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
-                await page.goto(dmURL, {waitUntil: 'load'});
-
-                const sidebar = new Sidebar(page);
-
-                // * Unconnected version of icon should be visible
-                await expect(sidebar.containerUnconnected).toBeVisible();
-
-                // * Unconnected version of icon should have the connect link
-                await expect(sidebar.containerUnconnected).toHaveAttribute('href', '/plugins/github/oauth/connect');
+                await expect(sidebar.getCounter(GithubRHSCategory.OPEN_PR)).toHaveText(expectedData[GithubRHSCategory.OPEN_PR].count);
+                await expect(sidebar.getCounter(GithubRHSCategory.REVIEW_PR)).toHaveText(expectedData[GithubRHSCategory.REVIEW_PR].count);
+                await expect(sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS)).toHaveText(expectedData[GithubRHSCategory.ASSIGNMENTS].count);
+                await expect(sidebar.getCounter(GithubRHSCategory.UNREAD)).toHaveText(expectedData[GithubRHSCategory.UNREAD].count);
             });
         });
     },

--- a/e2e/playwright/tests/ui/sidebar.spec.ts
+++ b/e2e/playwright/tests/ui/sidebar.spec.ts
@@ -9,6 +9,7 @@
 import {expect, test} from '@e2e-support/test_fixture';
 
 import {GithubRHSCategory} from '../../support/components/todo_message';
+import Sidebar from '../../support/components/sidebar';
 import {expectedData} from '../../support/constants';
 import {getGithubBotDMPageURL} from '../../support/utils';
 
@@ -23,23 +24,25 @@ export default {
                 const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
                 await page.goto(dmURL, {waitUntil: 'load'});
 
+                const sidebar = new Sidebar(page);
+
                 // * Unconnected version of icon shouldn't be visible
-                await expect(page.getByTestId('sidebar-github-unconnected')).not.toBeVisible();
+                await expect(sidebar.containerUnconnected).not.toBeVisible();
 
                 // * Counters must be visible
-                await expect(page.getByTestId('sidebar-github')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-openpr')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-reviewpr')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-assignments')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-unreads')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-refresh')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-refresh')).toBeEnabled();
+                await expect(sidebar.container).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.OPEN_PR)).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.REVIEW_PR)).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS)).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.UNREAD)).toBeVisible();
+                await expect(sidebar.refresh).toBeVisible();
+                await expect(sidebar.refresh).toBeEnabled();
 
                 // * Assert counters before refresh
-                await expect(page.getByTestId('sidebar-github-openpr')).toHaveText('0');
-                await expect(page.getByTestId('sidebar-github-reviewpr')).toHaveText('0');
-                await expect(page.getByTestId('sidebar-github-assignments')).toHaveText('0');
-                await expect(page.getByTestId('sidebar-github-unreads')).toHaveText('0');
+                await expect(sidebar.getCounter(GithubRHSCategory.OPEN_PR)).toHaveText('0');
+                await expect(sidebar.getCounter(GithubRHSCategory.REVIEW_PR)).toHaveText('0');
+                await expect(sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS)).toHaveText('0');
+                await expect(sidebar.getCounter(GithubRHSCategory.UNREAD)).toHaveText('0');
             });
 
             test('from connected account (after refresh)', async ({page, pw}) => {
@@ -50,29 +53,31 @@ export default {
                 const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
                 await page.goto(dmURL, {waitUntil: 'load'});
 
+                const sidebar = new Sidebar(page);
+
                 // * Unconnected version of icon shouldn't be visible
-                await expect(page.getByTestId('sidebar-github-unconnected')).not.toBeVisible();
+                await expect(sidebar.containerUnconnected).not.toBeVisible();
 
                 // # Click refresh data (fetch, impacts rate limit)
-                await page.getByTestId('sidebar-github-refresh').click();
+                await sidebar.refresh.click();
 
                 // # Waits for 1sec
                 await page.waitForTimeout(1000);
 
                 // * Counters must be visible
-                await expect(page.getByTestId('sidebar-github')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-openpr')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-reviewpr')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-assignments')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-unreads')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-refresh')).toBeVisible();
-                await expect(page.getByTestId('sidebar-github-refresh')).toBeEnabled();
+                await expect(sidebar.container).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.OPEN_PR)).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.REVIEW_PR)).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS)).toBeVisible();
+                await expect(sidebar.getCounter(GithubRHSCategory.UNREAD)).toBeVisible();
+                await expect(sidebar.refresh).toBeVisible();
+                await expect(sidebar.refresh).toBeEnabled();
 
                 // * Assert counters before refresh
-                await expect(page.getByTestId('sidebar-github-openpr')).toHaveText(expectedData[GithubRHSCategory.OPEN_PR]);
-                await expect(page.getByTestId('sidebar-github-reviewpr')).toHaveText(expectedData[GithubRHSCategory.REVIEW_PR]);
-                await expect(page.getByTestId('sidebar-github-assignments')).toHaveText(expectedData[GithubRHSCategory.ASSIGNMENTS]);
-                await expect(page.getByTestId('sidebar-github-unreads')).toHaveText(expectedData[GithubRHSCategory.UNREAD]);
+                await expect(sidebar.getCounter(GithubRHSCategory.OPEN_PR)).toHaveText(expectedData[GithubRHSCategory.OPEN_PR]);
+                await expect(sidebar.getCounter(GithubRHSCategory.REVIEW_PR)).toHaveText(expectedData[GithubRHSCategory.REVIEW_PR]);
+                await expect(sidebar.getCounter(GithubRHSCategory.ASSIGNMENTS)).toHaveText(expectedData[GithubRHSCategory.ASSIGNMENTS]);
+                await expect(sidebar.getCounter(GithubRHSCategory.UNREAD)).toHaveText(expectedData[GithubRHSCategory.UNREAD]);
             });
         });
     },
@@ -86,11 +91,13 @@ export default {
                 const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
                 await page.goto(dmURL, {waitUntil: 'load'});
 
+                const sidebar = new Sidebar(page);
+
                 // * Unconnected version of icon should be visible
-                await expect(page.getByTestId('sidebar-github-unconnected')).toBeVisible();
+                await expect(sidebar.containerUnconnected).toBeVisible();
 
                 // * Unconnected version of icon should have the connect link
-                await expect(page.getByTestId('sidebar-github-unconnected')).toHaveAttribute('href', '/plugins/github/oauth/connect');
+                await expect(sidebar.containerUnconnected).toHaveAttribute('href', '/plugins/github/oauth/connect');
             });
         });
     },
@@ -104,11 +111,13 @@ export default {
                 const dmURL = await getGithubBotDMPageURL(adminClient, '', adminUser.id);
                 await page.goto(dmURL, {waitUntil: 'load'});
 
+                const sidebar = new Sidebar(page);
+
                 // * Unconnected version of icon should be visible
-                await expect(page.getByTestId('sidebar-github-unconnected')).toBeVisible();
+                await expect(sidebar.containerUnconnected).toBeVisible();
 
                 // * Unconnected version of icon should have the connect link
-                await expect(page.getByTestId('sidebar-github-unconnected')).toHaveAttribute('href', '/plugins/github/oauth/connect');
+                await expect(sidebar.containerUnconnected).toHaveAttribute('href', '/plugins/github/oauth/connect');
             });
         });
     },

--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -974,7 +974,7 @@ func (p *Plugin) getYourAssignments(c *UserContext, w http.ResponseWriter, r *ht
 
 	username := c.GHInfo.GitHubUsername
 	query := getYourAssigneeSearchQuery(username, config.GitHubOrg)
-	result, _, err := githubClient.Search.Issues(c.Ctx, query, &github.SearchOptions{})
+	result, _, err := githubClient.Search.Issues(c.Ctx, query, &github.SearchOptions{ListOptions: github.ListOptions{PerPage: 100}})
 	if err != nil {
 		c.Log.WithError(err).With(logger.LogContext{"query": query}).Warnf("Failed to search for assignments")
 		return

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -785,7 +785,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		return "", errors.Wrap(err, "error occurred while searching for PRs")
 	}
 
-	yourAssignments, _, err := githubClient.Search.Issues(ctx, getYourAssigneeSearchQuery(username, config.GitHubOrg), &github.SearchOptions{})
+	yourAssignments, _, err := githubClient.Search.Issues(ctx, getYourAssigneeSearchQuery(username, config.GitHubOrg), &github.SearchOptions{ListOptions: github.ListOptions{PerPage: 100}})
 	if err != nil {
 		return "", errors.Wrap(err, "error occurred while searching for assignments")
 	}
@@ -898,7 +898,7 @@ func (p *Plugin) HasUnreads(info *GitHubUserInfo) bool {
 	}
 
 	query = getYourAssigneeSearchQuery(username, config.GitHubOrg)
-	yourAssignments, _, err := githubClient.Search.Issues(ctx, query, &github.SearchOptions{})
+	yourAssignments, _, err := githubClient.Search.Issues(ctx, query, &github.SearchOptions{ListOptions: github.ListOptions{PerPage: 100}})
 	if err != nil {
 		p.client.Log.Warn("Failed to search for assignments", "query", query, "error", "error", err.Error())
 		return false

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -59,11 +59,12 @@ export default class SidebarButtons extends React.PureComponent {
         }
 
         // Avoid refreshing data on each test when doing e2e testing.
-        // It requires __E2E_TESTING__ env/webpack-flag set and skip_github_fetch query param.
+        // It requires __E2E_TESTING__ env/webpack-flag set, skip_github_fetch query param and
+        // lack event e (we still process refresh click).
         // Otherwise we'll load app on each test consuming 3 searches from 30 rate limit.
         const params = new URLSearchParams(window.location.search);
         // eslint-disable-next-line no-undef
-        if (__E2E_TESTING__ && params.get('skip_github_fetch') === 'true') {
+        if (!e && __E2E_TESTING__ && params.get('skip_github_fetch') === 'true') {
             return;
         }
 
@@ -113,6 +114,7 @@ export default class SidebarButtons extends React.PureComponent {
                         overlay={<Tooltip id='reviewTooltip'>{'Connect to your GitHub'}</Tooltip>}
                     >
                         <a
+                            data-testid='sidebar-github-unconnected'
                             href='/plugins/github/oauth/connect'
                             onClick={this.openConnectWindow}
                             style={button}
@@ -137,7 +139,10 @@ export default class SidebarButtons extends React.PureComponent {
         }
 
         return (
-            <div style={container}>
+            <div
+                style={container}
+                data-testid='sidebar-github'
+            >
                 <a
                     key='githubHeader'
                     href={baseURL + '/settings/connections/applications/' + this.props.clientId}
@@ -153,6 +158,7 @@ export default class SidebarButtons extends React.PureComponent {
                     overlay={<Tooltip id='yourPrsTooltip'>{'Your open pull requests'}</Tooltip>}
                 >
                     <a
+                        data-testid='sidebar-github-openpr'
                         style={button}
                         onClick={() => this.openRHS(RHSStates.PRS)}
                     >
@@ -166,6 +172,7 @@ export default class SidebarButtons extends React.PureComponent {
                     overlay={<Tooltip id='reviewTooltip'>{'Pull requests needing review'}</Tooltip>}
                 >
                     <a
+                        data-testid='sidebar-github-reviewpr'
                         onClick={() => this.openRHS(RHSStates.REVIEWS)}
                         style={button}
                     >
@@ -179,6 +186,7 @@ export default class SidebarButtons extends React.PureComponent {
                     overlay={<Tooltip id='reviewTooltip'>{'Your assignments'}</Tooltip>}
                 >
                     <a
+                        data-testid='sidebar-github-assignments'
                         onClick={() => this.openRHS(RHSStates.ASSIGNMENTS)}
                         style={button}
                     >
@@ -192,6 +200,7 @@ export default class SidebarButtons extends React.PureComponent {
                     overlay={<Tooltip id='unreadsTooltip'>{'Unread messages'}</Tooltip>}
                 >
                     <a
+                        data-testid='sidebar-github-unreads'
                         onClick={() => this.openRHS(RHSStates.UNREADS)}
                         style={button}
                     >
@@ -205,6 +214,7 @@ export default class SidebarButtons extends React.PureComponent {
                     overlay={<Tooltip id='refreshTooltip'>{'Refresh'}</Tooltip>}
                 >
                     <a
+                        data-testid='sidebar-github-refresh'
                         href='#'
                         style={button}
                         onClick={this.getData}

--- a/webapp/src/components/sidebar_right/github_items.tsx
+++ b/webapp/src/components/sidebar_right/github_items.tsx
@@ -144,6 +144,7 @@ function GithubItems(props: GithubItemsProps) {
         if (item.html_url) {
             title = (
                 <a
+                    data-testid='github-item-title'
                     href={item.html_url}
                     target='_blank'
                     aria-label={titleText}
@@ -156,6 +157,7 @@ function GithubItems(props: GithubItemsProps) {
                 number = (
                     <strong>
                         <a
+                            data-testid='github-item-id'
                             href={item.html_url}
                             target='_blank'
                             rel='noopener noreferrer'
@@ -195,6 +197,7 @@ function GithubItems(props: GithubItemsProps) {
             case 'success':
                 status = (
                     <span
+                        data-testid='github-item-status-success'
                         title={'Success'}
                         aria-label={'Success'}
                         role={'note'}
@@ -220,6 +223,7 @@ function GithubItems(props: GithubItemsProps) {
                         }
                     >
                         <span
+                            data-testid='github-item-status-pending'
                             style={{...style.icon, ...style.iconPending}}
                         >
                             <DotIcon/>
@@ -243,6 +247,7 @@ function GithubItems(props: GithubItemsProps) {
                         }
                     >
                         <span
+                            data-testid='github-item-status-default'
                             style={{...style.icon, ...style.iconFailed}}
                         >
                             <CrossIcon/>
@@ -293,10 +298,15 @@ function GithubItems(props: GithubItemsProps) {
                     </strong>
                 </div>
                 <div>
-                    {number} <span className='light'>{'(' + repoName + ')'}</span>
+                    {number}
+                    <span
+                        className='light'
+                        data-testid='github-item-repo'
+                    >{'(' + repoName + ')'}</span>
                 </div>
                 {labels}
                 <div
+                    data-testid='github-item-description'
                     className='light'
                     style={style.subtitle}
                 >

--- a/webapp/src/components/sidebar_right/github_items.tsx
+++ b/webapp/src/components/sidebar_right/github_items.tsx
@@ -283,6 +283,7 @@ function GithubItems(props: GithubItemsProps) {
 
         return (
             <div
+                data-testid='github-rhs-item'
                 key={item.id}
                 style={style.container}
             >

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -149,7 +149,10 @@ export default class SidebarRight extends React.PureComponent {
                     renderThumbVertical={renderThumbVertical}
                     renderView={renderView}
                 >
-                    <div style={style.sectionHeader}>
+                    <div
+                        data-testid='github-rhs-title'
+                        style={style.sectionHeader}
+                    >
                         <strong>
                             <a
                                 href={listUrl}
@@ -158,7 +161,7 @@ export default class SidebarRight extends React.PureComponent {
                             >{title}</a>
                         </strong>
                     </div>
-                    <div>
+                    <div data-testid='github-rhs-list'>
                         <GithubItems
                             items={githubItems}
                             theme={this.props.theme}


### PR DESCRIPTION
#### Summary
LHS counters e2e test:
- expected data extracted to constants
- tested connected but without data (fetch prevented)
- tested connected with data (fetch forced through refresh)

RHS tests for the 4 sections:
- rhs title and rhs subtitle 
- item count
- for the first item check: title, id, links, description and repo (milestone and labels not tested yet)


Still 2/5 on the perpage change from default to 100

TODO:
- clean assignments data

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-51372
