### PR TITLE
Make playwright tests run off of ci workflow run

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,10 +2,10 @@ name: Playwright Tests
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
 
 env:
   TERM: xterm


### PR DESCRIPTION
#### Summary

Playwright tests are currently failing for fork PRs. This PR solves this by running the workflow alongside the `ci` workflow, to access variables for the Mattermost project during the workflow run.

Context https://community.mattermost.com/core/pl/buyo3qkq8tdm9yeobg6dsih4gy

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-53014