### PR TITLE
Remove duplicate oauth step

### DIFF
--- a/server/plugin/flows.go
+++ b/server/plugin/flows.go
@@ -84,7 +84,6 @@ func (p *Plugin) NewFlowManager() *FlowManager {
 	fm.oauthFlow = fm.newFlow("oauth").WithSteps(
 		fm.stepEnterprise(),
 		fm.stepOAuthInfo(),
-		fm.stepOAuthInfo(),
 		fm.stepOAuthInput(),
 		fm.stepOAuthConnect().Terminal(),
 


### PR DESCRIPTION
#### Summary
This PR removes a duplicate step from the oauth setup flow. Please note that this change doesn't impact users -  the flow library already ensured that duplicate steps don't get shown.

#### Ticket Link
None