### PR TITLE
[GH-692] Fix formatting inside code block in issue created notification

### DIFF
--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -460,8 +460,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 func (p *Plugin) sanitizeDescription(description string) string {
 	var policy = bluemonday.StrictPolicy()
 	policy.SkipElementsContent("details")
-	result := policy.Sanitize(description)
-	html.UnescapeString(result)
+	result := html.UnescapeString(policy.Sanitize(description))
 	return strings.TrimSpace(result)
 }
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1" //nolint:gosec // GitHub webhooks are signed using sha1 https://developer.github.com/webhooks/.
 	"encoding/hex"
 	"encoding/json"
+	"html"
 	"io"
 	"net/http"
 	"strings"
@@ -459,12 +460,8 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 func (p *Plugin) sanitizeDescription(description string) string {
 	var policy = bluemonday.StrictPolicy()
 	policy.SkipElementsContent("details")
-	// Replacing the unicodes with the respective special characters to have proper rendering in code block.
-	result := strings.ReplaceAll(policy.Sanitize(description), "&#39;", "'")
-	result = strings.ReplaceAll(result, "&#34;", "\"")
-	result = strings.ReplaceAll(result, "&amp;", "&")
-	result = strings.ReplaceAll(result, "&gt;", ">")
-	result = strings.ReplaceAll(result, "&lt;", "<")
+	result := policy.Sanitize(description)
+	html.UnescapeString(result)
 	return strings.TrimSpace(result)
 }
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -459,7 +459,11 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 func (p *Plugin) sanitizeDescription(description string) string {
 	var policy = bluemonday.StrictPolicy()
 	policy.SkipElementsContent("details")
-	return strings.TrimSpace(policy.Sanitize(description))
+	// Replacing the unicodes with the respective special characters to have proper rendering in code block.
+	result := strings.ReplaceAll(policy.Sanitize(description), "&#39;", "'")
+	result = strings.ReplaceAll(result, "&#34;", "\"")
+	result = strings.ReplaceAll(result, "&amp;", "&")
+	return strings.TrimSpace(result)
 }
 
 func (p *Plugin) handlePRDescriptionMentionNotification(event *github.PullRequestEvent) {

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -463,6 +463,8 @@ func (p *Plugin) sanitizeDescription(description string) string {
 	result := strings.ReplaceAll(policy.Sanitize(description), "&#39;", "'")
 	result = strings.ReplaceAll(result, "&#34;", "\"")
 	result = strings.ReplaceAll(result, "&amp;", "&")
+	result = strings.ReplaceAll(result, "&gt;", ">")
+	result = strings.ReplaceAll(result, "&lt;", "<")
 	return strings.TrimSpace(result)
 }
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -458,10 +458,12 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 }
 
 func (p *Plugin) sanitizeDescription(description string) string {
-	var policy = bluemonday.StrictPolicy()
-	policy.SkipElementsContent("details")
-	result := html.UnescapeString(policy.Sanitize(description))
-	return strings.TrimSpace(result)
+	if strings.Contains(description, "<details>") {
+		var policy = bluemonday.StrictPolicy()
+		policy.SkipElementsContent("details")
+		description = html.UnescapeString(policy.Sanitize(description))
+	}
+	return strings.TrimSpace(description)
 }
 
 func (p *Plugin) handlePRDescriptionMentionNotification(event *github.PullRequestEvent) {


### PR DESCRIPTION
#### Summary
Fixed the improper formatting of special characters inside the code block of issue-created channel notifications.

###### What to test?
- Special characters are properly displayed inside the code block present in the description of the issue-created notification.

#### Screenshots
Earlier:
![image](https://github.com/mattermost/mattermost-plugin-github/assets/55234496/198219bb-0075-4d07-813b-e22ed234b6ae)

Now:
![image](https://github.com/mattermost/mattermost-plugin-github/assets/55234496/c46a72ff-d08a-4ec7-874e-081839593767)

#### Ticket Link
Fixes #692 

