### PR TITLE
[GH-693] Fix improper rendering of some unreads in the response of "/github todo" command

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -839,7 +839,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 
 			notificationTitle := notificationSubject.GetTitle()
 			notificationURL := fixGithubNotificationSubjectURL(subjectURL, issueNum)
-			notificationContent += getToDoDisplayText(baseURL, notificationTitle, notificationURL, notificationType)
+			notificationContent += getToDoDisplayText(baseURL, notificationTitle, notificationURL, notificationType, n.GetRepository())
 		}
 
 		notificationCount++
@@ -860,7 +860,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v pull requests awaiting your review:\n", issueResults.GetTotal())
 
 		for _, pr := range issueResults.Issues {
-			text += getToDoDisplayText(baseURL, pr.GetTitle(), pr.GetHTMLURL(), "")
+			text += getToDoDisplayText(baseURL, pr.GetTitle(), pr.GetHTMLURL(), "", nil)
 		}
 	}
 
@@ -872,7 +872,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v open pull requests:\n", yourPrs.GetTotal())
 
 		for _, pr := range yourPrs.Issues {
-			text += getToDoDisplayText(baseURL, pr.GetTitle(), pr.GetHTMLURL(), "")
+			text += getToDoDisplayText(baseURL, pr.GetTitle(), pr.GetHTMLURL(), "", nil)
 		}
 	}
 
@@ -884,7 +884,7 @@ func (p *Plugin) GetToDo(ctx context.Context, username string, githubClient *git
 		text += fmt.Sprintf("You have %v assignments:\n", yourAssignments.GetTotal())
 
 		for _, assign := range yourAssignments.Issues {
-			text += getToDoDisplayText(baseURL, assign.GetTitle(), assign.GetHTMLURL(), "")
+			text += getToDoDisplayText(baseURL, assign.GetTitle(), assign.GetHTMLURL(), "", nil)
 		}
 	}
 

--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -337,7 +337,7 @@ func getToDoDisplayText(baseURL, title, url, notifType string, repository *githu
 
 	titlePart = fmt.Sprintf(": %s", title)
 	if url != "" {
-		titlePart = fmt.Sprintf("[%s](%s)", title, url)
+		titlePart = fmt.Sprintf(": [%s](%s)", title, url)
 	}
 
 	if notifType == "" {

--- a/server/plugin/utils_test.go
+++ b/server/plugin/utils_test.go
@@ -238,7 +238,7 @@ func TestGetToDoDisplayText(t *testing.T) {
 				"",
 				nil,
 			},
-			want: "* [mattermost/repo](https://github.com/mattermost/repo) [Issue title with less than 80 characters](https://github.com/mattermost/repo/issues/42)\n",
+			want: "* [mattermost/repo](https://github.com/mattermost/repo) : [Issue title with less than 80 characters](https://github.com/mattermost/repo/issues/42)\n",
 		},
 		{
 			name: "title longer than threshold, multi-word repo name & Issue notification type",
@@ -248,7 +248,7 @@ func TestGetToDoDisplayText(t *testing.T) {
 				"Issue",
 				nil,
 			},
-			want: "* [mattermost/...github](https://github.com/mattermost/mattermost-plugin-github) Issue [This is an issue title which has with more than 80 characters and is completely...](https://github.com/mattermost/mattermost-plugin-github/issues/42)\n",
+			want: "* [mattermost/...github](https://github.com/mattermost/mattermost-plugin-github) Issue : [This is an issue title which has with more than 80 characters and is completely...](https://github.com/mattermost/mattermost-plugin-github/issues/42)\n",
 		},
 		{
 			name: "title longer than threshold, multi-word repo name & Issue notification type",


### PR DESCRIPTION
#### Summary
The URL that was used to create the pretext of the unread message and the repo URL was missing in the body of Discussion and CheckSuite type unread. We updated the code to use the repo link present in the body of an unread message. Also, we couldn't find any possible way to get the URL of "Discussion" or "CheckSuite", so we are not displaying them as a link.

#### Screenshots
Earlier:
![image](https://github.com/Brightscout/mattermost-plugin-github/assets/55234496/f3f48a45-d254-48a3-be73-a0f5bb9e5a13)

Now:
![image](https://github.com/Brightscout/mattermost-plugin-github/assets/55234496/1a88bdd9-259e-45d7-a643-6c7f60a4c4c8)

#### Possible risk:
- If for some specific/unknown type of notification, the repo link is not present it might not be displayed properly.

#### What to test:
- Links in the response of the `/github todo` command are rendered and working properly.

###### Steps to reproduce
1. Connect your Github account to MM.
2. Create notifications of different types on Github, Like Discussion, checkSuite, PullRequest, etc.
3. Run the `/github todo` command in any MM channel.

###### Environment:
MM version: v7.8.2
Node version: 14.18.0
Go version: 1.19.0

#### Ticket Link
Fixes #693 