### PR TITLE
[GH-717] Implement subscription notification for pull request "reopened" event

### DIFF
--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -226,6 +226,10 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{- end }} by {{template "user" .GetSender}}.
 `))
 
+	template.Must(masterTemplate.New("reopenedPR").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}} Pull request {{template "pullRequest" .GetPullRequest}} was reopened by {{template "user" .GetSender}}.
+`))
+
 	template.Must(masterTemplate.New("pullRequestLabelled").Funcs(funcMap).Parse(`
 #### {{.GetPullRequest.GetTitle}}
 ##### {{template "eventRepoPullRequest" .}}

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -393,6 +393,22 @@ func TestClosedPRMessageTemplate(t *testing.T) {
 	})
 }
 
+func TestReopenedPRMessageTemplate(t *testing.T) {
+	t.Run("reopened", func(t *testing.T) {
+		expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) Pull request [#42 Leverage git-get-head](https://github.com/mattermost/mattermost-plugin-github/pull/42) was reopened by [panda](https://github.com/panda).
+`
+
+		actual, err := renderTemplate("reopenedPR", &github.PullRequestEvent{
+			Repo:        &repo,
+			PullRequest: &pullRequest,
+			Sender:      &user,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
 func TestPullRequestLabelledTemplate(t *testing.T) {
 	expected := `
 #### Leverage git-get-head

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -353,9 +353,16 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 	}
 
 	action := event.GetAction()
-	if action != actionOpened && action != actionReopened && action != actionMarkedReadyForReview && action != actionLabeled && action != actionClosed {
+	switch action {
+	case actionOpened,
+		actionReopened,
+		actionMarkedReadyForReview,
+		actionLabeled,
+		actionClosed:
+	default:
 		return
 	}
+
 	pr := event.GetPullRequest()
 	isPRInDraftState := pr.GetDraft()
 	eventLabel := event.GetLabel().GetName()

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -353,7 +353,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 	}
 
 	action := event.GetAction()
-	if action != actionOpened && action != actionMarkedReadyForReview && action != actionLabeled && action != actionClosed {
+	if action != actionOpened && action != actionReopened && action != actionMarkedReadyForReview && action != actionLabeled && action != actionClosed {
 		return
 	}
 	pr := event.GetPullRequest()
@@ -434,6 +434,16 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			}
 
 			post.Message = p.sanitizeDescription(newPRMessage)
+		}
+
+		if action == actionReopened {
+			reopenedPRMessage, err := renderTemplate("reopenedPR", event)
+			if err != nil {
+				p.client.Log.Warn("Failed to render template", "error", err.Error())
+				return
+			}
+
+			post.Message = p.sanitizeDescription(reopenedPRMessage)
 		}
 
 		if action == actionMarkedReadyForReview {


### PR DESCRIPTION
#### Summary
- Added logic to handle the case for pull request reopened webhook event.

#### Screenshot:
![image](https://github.com/mattermost/mattermost-plugin-github/assets/55234496/28ce8693-68fa-47c2-b0dd-17da15bbcf77)

#### What to test?
- Subscription notification for pull request reopened event is working properly.

###### Steps to reproduce:
1. Connect your GitHub account.
2. Create a subscription of event type "pulls" in a channel.
3. Reopen a closed PR on GitHub for the project you have created a subscription for.

###### Expected behavior:
- You should get a notification in the channel with the text similar to the above screenshot.

###### Environment:
MM version: v9.2.2
Node version: 14.18.0
Go version: 1.20.11

#### Ticket Link
Fixes #717 

