### PR TITLE
[GH-719] Pushed commits events: add option to show Author instead of committer

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -118,6 +118,13 @@
                 "type": "bool",
                 "help_text": "Allow the plugin to log the webhook event. The log level needs to be set to DEBUG.",
                 "default": false
+            },
+            {
+                "key": "PushedCommitsAuthor",
+                "display_name": "Pushed commits events: show Author instead of Committer:",
+                "type": "bool",
+                "help_text": "In \"Pushed commits\" event message, show commit Author instead of commit Committer. This may be useful when Author and Committer are commonly two different persons.",
+                "default": false
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."

--- a/plugin.json
+++ b/plugin.json
@@ -120,10 +120,10 @@
                 "default": false
             },
             {
-                "key": "PushedCommitsAuthor",
-                "display_name": "Pushed commits events: show Author instead of Committer:",
+                "key": "ShowAuthorInCommitNotification",
+                "display_name": "Show Author in commit notification:",
                 "type": "bool",
-                "help_text": "In \"Pushed commits\" event message, show commit Author instead of commit Committer. This may be useful when Author and Committer are commonly two different persons.",
+                "help_text": "In `Pushed commits` event notification, show commit author instead of commit committer.",
                 "default": false
             }
         ],

--- a/plugin.json
+++ b/plugin.json
@@ -123,7 +123,7 @@
                 "key": "ShowAuthorInCommitNotification",
                 "display_name": "Show Author in commit notification:",
                 "type": "bool",
-                "help_text": "In `Pushed commits` event notification, show commit author instead of commit committer.",
+                "help_text": "In `Pushes` event notification, show commit author instead of commit committer.",
                 "default": false
             }
         ],

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -38,7 +38,7 @@ type Configuration struct {
 	EnableCodePreview           string `json:"enablecodepreview"`
 	EnableWebhookEventLogging   bool   `json:"enablewebhookeventlogging"`
 	UsePreregisteredApplication bool   `json:"usepreregisteredapplication"`
-	ShowAuthorInCommitNotification         bool   `json:"showauthorIncommitnotification"`
+	ShowAuthorInCommitNotification         bool   `json:"showauthorincommitnotification"`
 }
 
 func (c *Configuration) ToMap() (map[string]interface{}, error) {

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -38,6 +38,7 @@ type Configuration struct {
 	EnableCodePreview           string `json:"enablecodepreview"`
 	EnableWebhookEventLogging   bool   `json:"enablewebhookeventlogging"`
 	UsePreregisteredApplication bool   `json:"usepreregisteredapplication"`
+	PushedCommitsAuthor         bool   `json:"pushedcommitsauthor"`
 }
 
 func (c *Configuration) ToMap() (map[string]interface{}, error) {

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -25,20 +25,20 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type Configuration struct {
-	GitHubOrg                   string `json:"githuborg"`
-	GitHubOAuthClientID         string `json:"githuboauthclientid"`
-	GitHubOAuthClientSecret     string `json:"githuboauthclientsecret"`
-	WebhookSecret               string `json:"webhooksecret"`
-	EnableLeftSidebar           bool   `json:"enableleftsidebar"`
-	EnablePrivateRepo           bool   `json:"enableprivaterepo"`
-	ConnectToPrivateByDefault   bool   `json:"connecttoprivatebydefault"`
-	EncryptionKey               string `json:"encryptionkey"`
-	EnterpriseBaseURL           string `json:"enterprisebaseurl"`
-	EnterpriseUploadURL         string `json:"enterpriseuploadurl"`
-	EnableCodePreview           string `json:"enablecodepreview"`
-	EnableWebhookEventLogging   bool   `json:"enablewebhookeventlogging"`
-	UsePreregisteredApplication bool   `json:"usepreregisteredapplication"`
-	ShowAuthorInCommitNotification         bool   `json:"showauthorincommitnotification"`
+	GitHubOrg                      string `json:"githuborg"`
+	GitHubOAuthClientID            string `json:"githuboauthclientid"`
+	GitHubOAuthClientSecret        string `json:"githuboauthclientsecret"`
+	WebhookSecret                  string `json:"webhooksecret"`
+	EnableLeftSidebar              bool   `json:"enableleftsidebar"`
+	EnablePrivateRepo              bool   `json:"enableprivaterepo"`
+	ConnectToPrivateByDefault      bool   `json:"connecttoprivatebydefault"`
+	EncryptionKey                  string `json:"encryptionkey"`
+	EnterpriseBaseURL              string `json:"enterprisebaseurl"`
+	EnterpriseUploadURL            string `json:"enterpriseuploadurl"`
+	EnableCodePreview              string `json:"enablecodepreview"`
+	EnableWebhookEventLogging      bool   `json:"enablewebhookeventlogging"`
+	UsePreregisteredApplication    bool   `json:"usepreregisteredapplication"`
+	ShowAuthorInCommitNotification bool   `json:"showauthorincommitnotification"`
 }
 
 func (c *Configuration) ToMap() (map[string]interface{}, error) {

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -38,7 +38,7 @@ type Configuration struct {
 	EnableCodePreview           string `json:"enablecodepreview"`
 	EnableWebhookEventLogging   bool   `json:"enablewebhookeventlogging"`
 	UsePreregisteredApplication bool   `json:"usepreregisteredapplication"`
-	PushedCommitsAuthor         bool   `json:"pushedcommitsauthor"`
+	ShowAuthorInCommitNotification         bool   `json:"showauthorIncommitnotification"`
 }
 
 func (c *Configuration) ToMap() (map[string]interface{}, error) {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/google/go-github/v41/github"
 	"github.com/pkg/errors"
 )
 
@@ -32,6 +33,7 @@ var mdCommentRegex = regexp.MustCompile(mdCommentRegexPattern)
 var gitHubUsernameRegex = regexp.MustCompile(gitHubUsernameRegexPattern)
 var masterTemplate *template.Template
 var gitHubToUsernameMappingCallback func(string) string
+var pushedCommitsAuthor bool
 
 func init() {
 	var funcMap = sprig.TxtFuncMap()
@@ -101,6 +103,14 @@ func init() {
 			dict[key] = values[i+1]
 		}
 		return dict, nil
+	}
+
+	funcMap["commitAuthor"] = func(commit *github.HeadCommit) *github.CommitAuthor {
+		if !pushedCommitsAuthor {
+			return commit.GetCommitter()
+		} else {
+			return commit.GetAuthor()
+		}
 	}
 
 	masterTemplate = template.Must(template.New("master").Funcs(funcMap).Parse(""))
@@ -273,7 +283,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 	template.Must(masterTemplate.New("pushedCommits").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} {{if .GetForced}}force-{{end}}pushed [{{len .Commits}} new commit{{if ne (len .Commits) 1}}s{{end}}]({{.GetCompare}}) to [\[{{.GetRepo.GetFullName}}:{{.GetRef | trimRef}}\]]({{.GetRepo.GetHTMLURL}}/tree/{{.GetRef | trimRef}}):
 {{range .Commits -}}
-[` + "`{{.GetID | substr 0 6}}`" + `]({{.GetURL}}) {{.GetMessage}} - {{.GetCommitter.GetName}}
+[` + "`{{.GetID | substr 0 6}}`" + `]({{.GetURL}}) {{.GetMessage}} - {{with . | commitAuthor}}{{.GetName}}{{end}}
 {{end -}}
 `))
 
@@ -431,6 +441,10 @@ func lookupMattermostUsername(githubUsername string) string {
 	}
 
 	return gitHubToUsernameMappingCallback(githubUsername)
+}
+
+func setPushedCommitsAuthor(value bool) {
+	pushedCommitsAuthor = value
 }
 
 func renderTemplate(name string, data interface{}) (string, error) {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -33,7 +33,7 @@ var mdCommentRegex = regexp.MustCompile(mdCommentRegexPattern)
 var gitHubUsernameRegex = regexp.MustCompile(gitHubUsernameRegexPattern)
 var masterTemplate *template.Template
 var gitHubToUsernameMappingCallback func(string) string
-var pushedCommitsAuthor bool
+var showAuthorInCommitNotification bool
 
 func init() {
 	var funcMap = sprig.TxtFuncMap()
@@ -106,7 +106,7 @@ func init() {
 	}
 
 	funcMap["commitAuthor"] = func(commit *github.HeadCommit) *github.CommitAuthor {
-		if !pushedCommitsAuthor {
+		if !showAuthorInCommitNotification {
 			return commit.GetCommitter()
 		} else {
 			return commit.GetAuthor()
@@ -443,8 +443,8 @@ func lookupMattermostUsername(githubUsername string) string {
 	return gitHubToUsernameMappingCallback(githubUsername)
 }
 
-func setPushedCommitsAuthor(value bool) {
-	pushedCommitsAuthor = value
+func setShowAuthorInCommitNotification(value bool) {
+	showAuthorInCommitNotification = value
 }
 
 func renderTemplate(name string, data interface{}) (string, error) {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -106,11 +106,11 @@ func init() {
 	}
 
 	funcMap["commitAuthor"] = func(commit *github.HeadCommit) *github.CommitAuthor {
-		if !showAuthorInCommitNotification {
-			return commit.GetCommitter()
-		} else {
+		if showAuthorInCommitNotification {
 			return commit.GetAuthor()
 		}
+		
+		return commit.GetCommitter()
 	}
 
 	masterTemplate = template.Must(template.New("master").Funcs(funcMap).Parse(""))

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -109,7 +109,7 @@ func init() {
 		if showAuthorInCommitNotification {
 			return commit.GetAuthor()
 		}
-		
+
 		return commit.GetCommitter()
 	}
 

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -750,6 +750,41 @@ func TestPushedCommitsTemplate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	})
+
+	t.Run("single commit, with 'Show Author in commit notifications'", func(t *testing.T) {
+		showAuthorInCommitNotification = true
+		defer func() {
+			showAuthorInCommitNotification = false
+		}()
+
+		expected := `
+[panda](https://github.com/panda) pushed [1 new commit](https://github.com/mattermost/mattermost-plugin-github/compare/master...branch) to [\[mattermost-plugin-github:branch\]](https://github.com/mattermost/mattermost-plugin-github/tree/branch):
+[` + "`a10867`" + `](https://github.com/mattermost/mattermost-plugin-github/commit/a10867b14bb761a232cd80139fbd4c0d33264240) Leverage git-get-head - lion
+`
+
+		actual, err := renderTemplate("pushedCommits", &github.PushEvent{
+			Repo:   &pushEventRepository,
+			Sender: &user,
+			Forced: bToP(false),
+			Commits: []*github.HeadCommit{
+				{
+					ID:      sToP("a10867b14bb761a232cd80139fbd4c0d33264240"),
+					URL:     sToP("https://github.com/mattermost/mattermost-plugin-github/commit/a10867b14bb761a232cd80139fbd4c0d33264240"),
+					Message: sToP("Leverage git-get-head"),
+					Committer: &github.CommitAuthor{
+						Name: sToP("panda"),
+					},
+					Author: &github.CommitAuthor{
+						Name: sToP("lion"),
+					},
+				},
+			},
+			Compare: sToP("https://github.com/mattermost/mattermost-plugin-github/compare/master...branch"),
+			Ref:     sToP("refs/heads/branch"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
 }
 
 func TestCreateMessageTemplate(t *testing.T) {

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -753,9 +753,9 @@ func TestPushedCommitsTemplate(t *testing.T) {
 
 	t.Run("single commit, with 'Show Author in commit notifications'", func(t *testing.T) {
 		showAuthorInCommitNotification = true
-		defer func() {
+		t.Cleanup(func() {
 			showAuthorInCommitNotification = false
-		}()
+		})
 
 		expected := `
 [panda](https://github.com/panda) pushed [1 new commit](https://github.com/mattermost/mattermost-plugin-github/compare/master...branch) to [\[mattermost-plugin-github:branch\]](https://github.com/mattermost/mattermost-plugin-github/tree/branch):

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -657,7 +657,7 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 		return
 	}
 
-	setPushedCommitsAuthor(p.configuration.PushedCommitsAuthor)
+	setShowAuthorInCommitNotification(p.configuration.ShowAuthorInCommitNotification)
 	pushedCommitsMessage, err := renderTemplate("pushedCommits", event)
 	if err != nil {
 		p.client.Log.Warn("Failed to render template", "error", err.Error())

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -657,6 +657,7 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 		return
 	}
 
+	setPushedCommitsAuthor(p.configuration.PushedCommitsAuthor)
 	pushedCommitsMessage, err := renderTemplate("pushedCommits", event)
 	if err != nil {
 		p.client.Log.Warn("Failed to render template", "error", err.Error())


### PR DESCRIPTION
#### Summary

Pushed commits events: add option to show Author instead of Committer.

#### Screenshot

![image](https://github.com/mattermost/mattermost-plugin-github/assets/167134/0c693e18-83ff-4e76-bd84-1676ab501d18)

#### What to test?

Before starting, some Mattermost channel should be subscribed to pushed commits notifications for a repo.

1. Go to plugin settings and set "Pushed commits events: show Author instead of Committer:" to true.
1. Create a git commit with committer != author. For example, "git am" a patch from someone else, or "git commit --author 'Test author <test@example.com>'" (example: https://github.com/FOULAB/eigma-test/commit/65ed77834f659a0498c5d02cc319e38bd12c50f3)
2. Push commit to GitHub
3. Observe the pushed commits notification.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/719
