### PR TITLE
[MM-166] Fix issue: decription not visible in tooltip and removed "see more" link

### DIFF
--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -66,13 +66,13 @@
 }
 
 .github-tooltip .tooltip-info .markdown-text {
+    max-height: 150px;
     line-height: 1.25;
+    overflow: hidden;
     word-break: break-word;
     word-wrap: break-word;
     overflow-wrap: break-word;
     font-size: 12px;
-    max-height: 150px;
-    overflow: hidden;
 }
 
 .github-tooltip .tooltip-info .markdown-text::-webkit-scrollbar {


### PR DESCRIPTION
#### Summary
- Fix issue: description not visible in tooltip.
- Removed the see more link in the tooltip.
- Set a max length for the tooltip description.

#### Screenshot
![image](https://github.com/mattermost/mattermost-plugin-github/assets/55234496/5edb8039-ce57-4bb3-be20-4c7688c400e2)

#### What to test
- Description and other contents are visible in the tooltip properly.
- "See more" link is removed
- When the description is very long it's getting trimmed.

###### Steps to test:
1. Connect your GitHub account
2. Hover over a PR/Issue link.

#### Ticket Link
Fixes #734 

