### PR TITLE
[GH-733] Updated the "issue_creations" subscription to post notification when an issue is labeled/reopened

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -79,7 +79,7 @@ func validateFeatures(features []string) (bool, []string) {
 	if valid && hasLabel {
 		// must have "pulls" or "issues" in features when using a label
 		for _, f := range features {
-			if f == featurePulls || f == featureIssues {
+			if f == featurePulls || f == featureIssues || f == featureIssueCreation {
 				return valid, invalidFeatures
 			}
 		}
@@ -414,7 +414,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 		if !ok {
 			msg := fmt.Sprintf("Invalid feature(s) provided: %s", strings.Join(ifs, ","))
 			if len(ifs) == 0 {
-				msg = "Feature list must have \"pulls\" or \"issues\" when using a label."
+				msg = "Feature list must have \"pulls\", \"issues\" or \"issue_creations\" when using a label."
 			}
 			return msg
 		}

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -589,7 +589,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 			continue
 		}
 
-		if sub.IssueCreations() && action != actionOpened {
+		if sub.IssueCreations() && action == actionClosed {
 			continue
 		}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -589,7 +589,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 			continue
 		}
 
-		if sub.IssueCreations() && action == actionClosed {
+		if sub.IssueCreations() && action != actionOpened && action != actionReopened && action != actionLabeled {
 			continue
 		}
 


### PR DESCRIPTION
#### Summary
- Updated the "issue_creations" subscription to post a notification when an issue is labeled/reopened

#### Screenshots
![image](https://github.com/mattermost/mattermost-plugin-github/assets/55234496/79e520fb-888b-4655-b50a-1333269e616b)

![image](https://github.com/mattermost/mattermost-plugin-github/assets/55234496/638de0b1-cdae-49f7-bdfd-ccdaba64f603)

#### What to test:
- Notification is getting posted when an existing issue is labeled in a channel with a subscription for `issue_creations,label:"label-name"`
- Notification is posted when an issue is reopened  in a channel with a subscription for `issue_creations`

###### Steps to test:
1. Connect your GitHub account
2. Create a subscription for `issue_creations,label:"label-name"` is a channel.
3. Add a label (same as present in the subscription) to an existing issue.

#### Ticket Link
Fixes #733 

