### PR TITLE
Bump go version for playwright test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   TERM: xterm
-  GO_VERSION: 1.19.6
+  GO_VERSION: 1.21
   NODE_VERSION: 16.15.0
 
 jobs:


### PR DESCRIPTION
#### Summary
The playwright test are currenly failing on `master` with `go: go.mod file indicates go 1.21, but maximum version supported by tidy is 1.19`. (https://github.com/mattermost/mattermost-plugin-github/actions/runs/8134028209/job/22226371191) Let's bump the go version there and see if that fixes things.

#### Ticket Link
NONE
