### PR TITLE
[MM-352] Add feature to publish release create and delete events

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ When you’ve tested the plugin and confirmed it’s working, notify your team s
    /github subscriptions add mattermost/mattermost-server --features issues,pulls,issue_comments,label:"Help Wanted"
    ```
   - The following flags are supported:
-     - `--features`: comma-delimited list of one or more of: issues, pulls, pulls_merged, pulls_created, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, label:"labelname". Defaults to pulls,issues,creates,deletes.
+     - `--features`: comma-delimited list of one or more of: issues, pulls, pulls_merged, pulls_created, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, releases, label:"labelname". Defaults to pulls,issues,creates,deletes.
      - `--exclude-org-member`: events triggered by organization members will not be delivered. It will be locked to the organization provided in the plugin configuration and it will only work for users whose membership is public. Note that organization members and collaborators are not the same.
      - `--render-style`: notifications will be delivered in the specified style (for example, the body of a pull request will not be displayed). Supported
      values are `collapsed`, `skip-body` or `default` (same as omitting the flag).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ As a system admin, you must create a webhook for each organization you want to r
    - **Content Type:** `application/json`
    - **Secret:** the webhook secret you copied previously.
 6. Select **Let me select individual events** for "Which events would you like to trigger this webhook?".
-7. Select the following events: `Branch or Tag creation`, `Branch or Tag deletion`, `Issue comments`, `Issues`, `Pull requests`, `Pull request review`, `Pull request review comments`, `Pushes`, `Stars`.
+7. Select the following events: `Branch or Tag creation`, `Branch or Tag deletion`, `Issue comments`, `Issues`, `Pull requests`, `Pull request review`, `Pull request review comments`, `Pushes`, `Stars`, `Releases`.
 7. Hit **Add Webhook** to save it.
 
 If you have multiple organizations, repeat the process starting from step 3 to create a webhook for each organization.

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -26,6 +26,7 @@ const (
 	featureIssueComments = "issue_comments"
 	featurePullReviews   = "pull_reviews"
 	featureStars         = "stars"
+	featureReleases      = "releases"
 )
 
 const (
@@ -44,6 +45,7 @@ var validFeatures = map[string]bool{
 	featureIssueComments: true,
 	featurePullReviews:   true,
 	featureStars:         true,
+	featureReleases:      true,
 }
 
 type Features string

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -896,7 +896,7 @@ func getAutocompleteData(config *Configuration) *model.AutocompleteData {
 
 	subscriptionsAdd := model.NewAutocompleteData("add", "[owner/repo] [features] [flags]", "Subscribe the current channel to receive notifications about opened pull requests and issues for an organization or repository. [features] and [flags] are optional arguments")
 	subscriptionsAdd.AddTextArgument("Owner/repo to subscribe to", "[owner/repo]", "")
-	subscriptionsAdd.AddNamedTextArgument("features", "Comma-delimited list of one or more of: issues, pulls, pulls_merged, pulls_created, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, label:\"<labelname>\". Defaults to pulls,issues,creates,deletes", "", `/[^,-\s]+(,[^,-\s]+)*/`, false)
+	subscriptionsAdd.AddNamedTextArgument("features", "Comma-delimited list of one or more of: issues, pulls, pulls_merged, pulls_created, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, releases, label:\"<labelname>\". Defaults to pulls,issues,creates,deletes", "", `/[^,-\s]+(,[^,-\s]+)*/`, false)
 
 	if config.GitHubOrg != "" {
 		subscriptionsAdd.AddNamedStaticListArgument("exclude-org-member", "Events triggered by organization members will not be delivered (the organization config should be set, otherwise this flag has not effect)", false, []model.AutocompleteListItem{

--- a/server/plugin/subscriptions.go
+++ b/server/plugin/subscriptions.go
@@ -123,6 +123,10 @@ func (s *Subscription) Stars() bool {
 	return strings.Contains(s.Features.String(), featureStars)
 }
 
+func (s *Subscription) Release() bool {
+	return strings.Contains(s.Features.String(), featureReleases)
+}
+
 func (s *Subscription) Label() string {
 	if !strings.Contains(s.Features.String(), "label:") {
 		return ""

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -158,6 +158,11 @@ func init() {
 		`[#{{.GetNumber}} {{.GetTitle}}]({{.GetHTMLURL}})`,
 	))
 
+	// The release links to the corresponding release.
+	template.Must(masterTemplate.New("release").Parse(
+		`[{{.GetTagName}}]({{.GetHTMLURL}})`,
+	))
+
 	// The eventRepoIssue links to the corresponding issue. Note that, for some events, the
 	// issue *is* a pull request, and so we still use .GetIssue and this template accordingly.
 	template.Must(masterTemplate.New("eventRepoIssue").Parse(
@@ -408,6 +413,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 		"    	* `issue_comments` - includes new issue comments\n" +
 		"    	* `issue_creations` - includes new issues only \n" +
 		"    	* `pull_reviews` - includes pull request reviews\n" +
+		"		* `releases` - includes release created and deleted\n" +
 		"    	* `label:<labelname>` - limit pull request and issue events to only this label. Must include `pulls` or `issues` in feature list when using a label.\n" +
 		"    	* Defaults to `pulls,issues,creates,deletes`\n\n" +
 		"    * `--exclude-org-member` - events triggered by organization members will not be delivered (the GitHub organization config should be set, otherwise this flag has not effect)\n" +
@@ -429,6 +435,12 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{- else }} unstarred
 {{- end }} by {{template "user" .GetSender}}
 It now has **{{.GetRepo.GetStargazersCount}}** stars.`))
+
+	template.Must(masterTemplate.New("newReleaseEvent").Funcs(funcMap).Parse(`
+{{template "repo" .GetRepo}} {{template "user" .GetSender}}
+{{- if eq .GetAction "created" }} created a release {{template "release" .GetRelease}}
+{{- else if eq .GetAction "deleted" }} deleted a release {{template "release" .GetRelease}}
+{{- end -}}`))
 }
 
 func registerGitHubToUsernameMappingCallback(callback func(string) string) {

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -413,7 +413,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 		"    	* `issue_comments` - includes new issue comments\n" +
 		"    	* `issue_creations` - includes new issues only \n" +
 		"    	* `pull_reviews` - includes pull request reviews\n" +
-		"		* `releases` - includes release created and deleted\n" +
+		"    	* `releases` - includes release created and deleted\n" +
 		"    	* `label:<labelname>` - limit pull request and issue events to only this label. Must include `pulls` or `issues` in feature list when using a label.\n" +
 		"    	* Defaults to `pulls,issues,creates,deletes`\n\n" +
 		"    * `--exclude-org-member` - events triggered by organization members will not be delivered (the GitHub organization config should be set, otherwise this flag has not effect)\n" +

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -1407,6 +1407,42 @@ func TestPullRequestReviewNotification(t *testing.T) {
 	}))
 }
 
+func TestReleaseNotification(t *testing.T) {
+	t.Run("created", func(t *testing.T) {
+		expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) [panda](https://github.com/panda) created a release [v0.0.1](https://github.com/mattermost/mattermost-plugin-github/releases/tag/v0.0.1)`
+
+		actual, err := renderTemplate("newReleaseEvent", &github.ReleaseEvent{
+			Repo:   &repo,
+			Sender: &user,
+			Action: sToP(actionCreated),
+			Release: &github.RepositoryRelease{
+				TagName: sToP("v0.0.1"),
+				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/releases/tag/v0.0.1"),
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("deleted", func(t *testing.T) {
+		expected := `
+[\[mattermost-plugin-github\]](https://github.com/mattermost/mattermost-plugin-github) [panda](https://github.com/panda) deleted a release [v0.0.1](https://github.com/mattermost/mattermost-plugin-github/releases/tag/v0.0.1)`
+
+		actual, err := renderTemplate("newReleaseEvent", &github.ReleaseEvent{
+			Repo:   &repo,
+			Sender: &user,
+			Action: sToP(actionDeleted),
+			Release: &github.RepositoryRelease{
+				TagName: sToP("v0.0.1"),
+				HTMLURL: sToP("https://github.com/mattermost/mattermost-plugin-github/releases/tag/v0.0.1"),
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	})
+}
+
 func TestGitHubUsernameRegex(t *testing.T) {
 	stringAndMatchMap := map[string]string{
 		// Contain valid usernames

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -1401,18 +1401,18 @@ func (p *Plugin) postReleaseEvent(event *github.ReleaseEvent) {
 		return
 	}
 
-	post := &model.Post{
-		UserId:  p.BotUserID,
-		Type:    "custom_git_release",
-		Message: newReleaseMessage,
-	}
-
 	for _, sub := range subs {
 		if !sub.Release() {
 			continue
 		}
 
-		post.ChannelId = sub.ChannelID
+		post := &model.Post{
+			UserId:    p.BotUserID,
+			Type:      "custom_git_release",
+			Message:   newReleaseMessage,
+			ChannelId: sub.ChannelID,
+		}
+
 		if err = p.client.Post.CreatePost(post); err != nil {
 			p.client.Log.Warn("Error webhook post", "Post", post, "Error", err.Error())
 		}


### PR DESCRIPTION
#### Summary
- Added feature to publish release create and delete events

#### Screenshot 
![image](https://github.com/mattermost/mattermost-plugin-github/assets/100013900/4c215703-38c0-488c-b7b6-ee27ace2dbca)

#### Ticket Link
Fixes #723 

#### What to test?
- Update the webhook for the repo to receive notifications for release events
- Create a subscription for a repo with a subscription enabled for release events
- Create and delete a release on the subscribed repo
- Check for the events received in the subscribed channel

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks
