### PR TITLE
Fixes #497: "Validation Message spacing (UI) issue"

### DIFF
--- a/webapp/src/components/github_repo_selector/github_repo_selector.jsx
+++ b/webapp/src/components/github_repo_selector/github_repo_selector.jsx
@@ -42,7 +42,7 @@ export default class GithubRepoSelector extends PureComponent {
         const repoOptions = this.props.yourRepos.map((item) => ({value: item.full_name, label: item.full_name}));
 
         return (
-            <div className={'form-group margin-bottom x3'}>
+            <div className={'form-group x3'}>
                 <ReactSelectSetting
                     name={'repo'}
                     label={'Repository'}
@@ -57,8 +57,11 @@ export default class GithubRepoSelector extends PureComponent {
                     removeValidate={this.props.removeValidate}
                     value={repoOptions.find((option) => option.value === this.props.value)}
                 />
-                <div className={'help-text'}>
-                    {'Returns GitHub repositories connected to the user account'} <br/>
+                <div
+                    className={'help-text'}
+                    style={{marginTop: '8px', marginBottom: '24px'}}
+                >
+                    {'Returns GitHub repositories connected to the user account'}
                 </div>
             </div>
         );

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -161,7 +161,10 @@ export default class CreateIssueModal extends PureComponent {
         let issueTitleValidationError = null;
         if (this.state.showErrors && !this.state.issueTitleValid) {
             issueTitleValidationError = (
-                <p className='help-text error-text'>
+                <p 
+                    className='help-text error-text'
+                    style={{marginTop: '15px'}}
+                >
                     <span>{requiredMsg}</span>
                 </p>
             );

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -49,7 +49,11 @@ export default class CreateIssueModal extends PureComponent {
     componentDidUpdate(prevProps) {
         if (this.props.post && !prevProps.post) {
             this.setState({issueDescription: this.props.post.message}); //eslint-disable-line react/no-did-update-set-state
-        } else if (this.props.channelId && (this.props.channelId !== prevProps.channelId || this.props.title !== prevProps.title)) {
+        } else if (
+            this.props.channelId &&
+            (this.props.channelId !== prevProps.channelId ||
+                this.props.title !== prevProps.title)
+        ) {
             const title = this.props.title.substring(0, MAX_TITLE_LENGTH);
             this.setState({issueTitle: title}); // eslint-disable-line react/no-did-update-set-state
         }
@@ -70,7 +74,7 @@ export default class CreateIssueModal extends PureComponent {
         }
 
         const {post} = this.props;
-        const postId = (post) ? post.id : '';
+        const postId = post ? post.id : '';
 
         const issue = {
             title: this.state.issueTitle,
@@ -115,10 +119,14 @@ export default class CreateIssueModal extends PureComponent {
 
     handleIssueTitleChange = (issueTitle) => this.setState({issueTitle});
 
-    handleIssueDescriptionChange = (issueDescription) => this.setState({issueDescription});
+    handleIssueDescriptionChange = (issueDescription) =>
+        this.setState({issueDescription});
 
     renderIssueAttributeSelectors = () => {
-        if (!this.state.repo || (this.state.repo.permissions && !this.state.repo.permissions.push)) {
+        if (
+            !this.state.repo ||
+            (this.state.repo.permissions && !this.state.repo.permissions.push)
+        ) {
             return null;
         }
 
@@ -146,7 +154,7 @@ export default class CreateIssueModal extends PureComponent {
                 />
             </>
         );
-    }
+    };
 
     render() {
         if (!this.props.visible) {
@@ -163,7 +171,7 @@ export default class CreateIssueModal extends PureComponent {
             issueTitleValidationError = (
                 <p
                     className='help-text error-text'
-                    style={{marginTop: '15px'}}
+                    style={{marginTop: '15px', marginBottom: '15px'}}
                 >
                     <span>{requiredMsg}</span>
                 </p>
@@ -223,9 +231,7 @@ export default class CreateIssueModal extends PureComponent {
                 backdrop='static'
             >
                 <Modal.Header closeButton={true}>
-                    <Modal.Title>
-                        {'Create GitHub Issue'}
-                    </Modal.Title>
+                    <Modal.Title>{'Create GitHub Issue'}</Modal.Title>
                 </Modal.Header>
                 <form
                     role='form'

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -161,7 +161,7 @@ export default class CreateIssueModal extends PureComponent {
         let issueTitleValidationError = null;
         if (this.state.showErrors && !this.state.issueTitleValid) {
             issueTitleValidationError = (
-                <p 
+                <p
                     className='help-text error-text'
                     style={{marginTop: '15px'}}
                 >

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -49,11 +49,7 @@ export default class CreateIssueModal extends PureComponent {
     componentDidUpdate(prevProps) {
         if (this.props.post && !prevProps.post) {
             this.setState({issueDescription: this.props.post.message}); //eslint-disable-line react/no-did-update-set-state
-        } else if (
-            this.props.channelId &&
-            (this.props.channelId !== prevProps.channelId ||
-                this.props.title !== prevProps.title)
-        ) {
+        } else if (this.props.channelId && (this.props.channelId !== prevProps.channelId || this.props.title !== prevProps.title)) {
             const title = this.props.title.substring(0, MAX_TITLE_LENGTH);
             this.setState({issueTitle: title}); // eslint-disable-line react/no-did-update-set-state
         }
@@ -123,10 +119,7 @@ export default class CreateIssueModal extends PureComponent {
         this.setState({issueDescription});
 
     renderIssueAttributeSelectors = () => {
-        if (
-            !this.state.repo ||
-            (this.state.repo.permissions && !this.state.repo.permissions.push)
-        ) {
+        if (!this.state.repo || (this.state.repo.permissions && !this.state.repo.permissions.push)) {
             return null;
         }
 

--- a/webapp/src/components/modals/create_issue/create_issue.jsx
+++ b/webapp/src/components/modals/create_issue/create_issue.jsx
@@ -171,7 +171,7 @@ export default class CreateIssueModal extends PureComponent {
             issueTitleValidationError = (
                 <p
                     className='help-text error-text'
-                    style={{marginTop: '15px', marginBottom: '15px'}}
+                    style={{marginTop: '8px', marginBottom: '24px'}}
                 >
                     <span>{requiredMsg}</span>
                 </p>

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -97,7 +97,7 @@ export default class ReactSelectSetting extends React.PureComponent {
         let validationError = null;
         if (this.props.required && this.state.invalid) {
             validationError = (
-                <p 
+                <p
                     className='help-text error-text'
                     style={{marginTop: '15px'}}
                 >

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -99,7 +99,7 @@ export default class ReactSelectSetting extends React.PureComponent {
             validationError = (
                 <p
                     className='help-text error-text'
-                    style={{marginTop: '8px'}}
+                    style={{marginTop: '8px', marginBottom: '8px'}}
                 >
                     <span>{requiredMsg}</span>
                 </p>

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -99,7 +99,7 @@ export default class ReactSelectSetting extends React.PureComponent {
             validationError = (
                 <p
                     className='help-text error-text'
-                    style={{marginTop: '15px'}}
+                    style={{marginTop: '8px'}}
                 >
                     <span>{requiredMsg}</span>
                 </p>

--- a/webapp/src/components/react_select_setting.jsx
+++ b/webapp/src/components/react_select_setting.jsx
@@ -97,7 +97,10 @@ export default class ReactSelectSetting extends React.PureComponent {
         let validationError = null;
         if (this.props.required && this.state.invalid) {
             validationError = (
-                <p className='help-text error-text'>
+                <p 
+                    className='help-text error-text'
+                    style={{marginTop: '15px'}}
+                >
                     <span>{requiredMsg}</span>
                 </p>
             );

--- a/webapp/src/components/setting.jsx
+++ b/webapp/src/components/setting.jsx
@@ -25,7 +25,10 @@ export default class Setting extends React.PureComponent {
         } = this.props;
 
         return (
-            <div className='form-group less'>
+            <div
+                className='form-group less'
+                style={{marginBottom: '8px'}}
+            >
                 {label && (
                     <label
                         className='control-label margin-bottom x2'

--- a/webapp/src/components/setting.jsx
+++ b/webapp/src/components/setting.jsx
@@ -45,7 +45,10 @@ export default class Setting extends React.PureComponent {
                 }
                 <div>
                     {children}
-                    <div className='help-text'>
+                    <div
+                        className='help-text'
+                        style={{margin: '0px'}}
+                    >
                         {helpText}
                     </div>
                 </div>


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/497

![image](https://github.com/mattermost/mattermost-plugin-github/assets/32754336/4435fa47-de14-4fe4-b329-691f22266abd)

Used inline style to avoid other possible changes to either 'error-text' or 'help-text'

Spaces now match the spacing between "Returns Github repositories....", "This field is required", and the fields themselves.

Edit: Accidentally linked wrong issue (498)





