### PR TITLE
[GH-670] Fix issue: Code previews not working for branches

### DIFF
--- a/server/plugin/permalinks.go
+++ b/server/plugin/permalinks.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"encoding/hex"
 	"path"
 	"strings"
 	"time"
@@ -94,11 +93,6 @@ func (p *Plugin) makeReplacements(msg string, replacements []replacement, ghClie
 	// iterating the slice in reverse to preserve the replacement indices.
 	for i := len(replacements) - 1; i >= 0; i-- {
 		r := replacements[i]
-		// quick bailout if the commit hash is not proper.
-		if _, err := hex.DecodeString(r.permalinkInfo.commit); err != nil {
-			p.client.Log.Warn("Bad git commit hash in permalink", "error", err.Error(), "hash", r.permalinkInfo.commit)
-			continue
-		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), permalinkReqTimeout)
 		defer cancel()

--- a/server/plugin/permalinks_test.go
+++ b/server/plugin/permalinks_test.go
@@ -284,7 +284,7 @@ func TestMakeReplacements(t *testing.T) {
 		replacements []replacement
 	}{
 		{
-			name:   "basic one link",
+			name:   "basic one link with commit hash",
 			input:  "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
 			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
 			replacements: []replacement{
@@ -354,13 +354,13 @@ func TestMakeReplacements(t *testing.T) {
 			},
 		},
 		{
-			name:   "bad commit hash",
-			input:  "start https://github.com/mattermost/mattermost-server/blob/badhash/app/authentication.go#L15-L22 lorem ipsum",
-			output: "start https://github.com/mattermost/mattermost-server/blob/badhash/app/authentication.go#L15-L22 lorem ipsum",
+			name:   "link with branch name",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
 			replacements: []replacement{
 				{
 					index: 6,
-					word:  "https://github.com/mattermost/mattermost-server/blob/badhash/app/authentication.go#L15-L22",
+					word:  "https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22",
 					permalinkInfo: struct {
 						haswww string
 						commit string
@@ -370,7 +370,7 @@ func TestMakeReplacements(t *testing.T) {
 						line   string
 					}{
 						haswww: "",
-						commit: "badhash",
+						commit: "master",
 						line:   "L15-L22",
 						path:   "app/authentication.go",
 						user:   "mattermost",
@@ -442,7 +442,6 @@ func TestMakeReplacements(t *testing.T) {
 		})
 	}
 
-	mockPluginAPI.AssertCalled(t, "LogWarn", "Bad git commit hash in permalink", "error", "encoding/hex: invalid byte: U+0068 'h'", "hash", "badhash")
 	mockPluginAPI.AssertCalled(t, "LogWarn", "Error while fetching file contents", "error", "unmarshalling failed for both file and directory content: unexpected end of JSON input and unexpected end of JSON input", "path", "path/file.go")
 }
 

--- a/server/plugin/permalinks_test.go
+++ b/server/plugin/permalinks_test.go
@@ -355,12 +355,12 @@ func TestMakeReplacements(t *testing.T) {
 		},
 		{
 			name:   "link with branch name",
-			input:  "start https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22 lorem ipsum",
-			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/TEST-branch_1/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/TEST-branch_1/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
 			replacements: []replacement{
 				{
 					index: 6,
-					word:  "https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22",
+					word:  "https://github.com/mattermost/mattermost-server/blob/TEST-branch_1/app/authentication.go#L15-L22",
 					permalinkInfo: struct {
 						haswww string
 						commit string

--- a/server/plugin/permalinks_test.go
+++ b/server/plugin/permalinks_test.go
@@ -355,12 +355,12 @@ func TestMakeReplacements(t *testing.T) {
 		},
 		{
 			name:   "link with branch name",
-			input:  "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
-			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
 			replacements: []replacement{
 				{
 					index: 6,
-					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
+					word:  "https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22",
 					permalinkInfo: struct {
 						haswww string
 						commit string

--- a/server/plugin/permalinks_test.go
+++ b/server/plugin/permalinks_test.go
@@ -355,12 +355,12 @@ func TestMakeReplacements(t *testing.T) {
 		},
 		{
 			name:   "link with branch name",
-			input:  "start https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22 lorem ipsum",
-			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
+			input:  "start https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22 lorem ipsum",
+			output: "start \n[mattermost/mattermost-server/app/authentication.go](https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22)\n```go\ntype TokenLocation int\n\nconst (\n\tTokenLocationNotFound TokenLocation = iota\n\tTokenLocationHeader\n\tTokenLocationCookie\n\tTokenLocationQueryString\n)\n```\n lorem ipsum",
 			replacements: []replacement{
 				{
 					index: 6,
-					word:  "https://github.com/mattermost/mattermost-server/blob/master/app/authentication.go#L15-L22",
+					word:  "https://github.com/mattermost/mattermost-server/blob/cbb25838a61872b624ac512556d7bc932486a64c/app/authentication.go#L15-L22",
 					permalinkInfo: struct {
 						haswww string
 						commit string

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -109,7 +109,7 @@ type Plugin struct {
 // NewPlugin returns an instance of a Plugin.
 func NewPlugin() *Plugin {
 	p := &Plugin{
-		githubPermalinkRegex: regexp.MustCompile(`https?://(?P<haswww>www\.)?github\.com/(?P<user>[\w-]+)/(?P<repo>[\w-.]+)/blob/(?P<commit>\w+)/(?P<path>[\w-/.]+)#(?P<line>[\w-]+)?`),
+		githubPermalinkRegex: regexp.MustCompile(`https?://(?P<haswww>www\.)?github\.com/(?P<user>[\w-]+)/(?P<repo>[\w-.]+)/blob/(?P<commit>[\w-]+)/(?P<path>[\w-/.]+)#(?P<line>[\w-]+)?`),
 	}
 
 	p.CommandHandlers = map[string]CommandHandleFunc{


### PR DESCRIPTION
#### Summary
- Update code to show code preview for permalink with branch names

#### What to test?
- Getting code preview for permalinks with branch names

###### Steps to reproduce:
1. Connect your GitHub account
2. Open a file on  a GitHub repo
3. Click on any line *number* in the file
4. Copy the browser URL
5. Post the link in the channel

###### Expected behavior:
- You should get a preview of the code near that permalink.

#### Ticket Link
Fixes #670 

