### PR TITLE
Update subscription messages with respect to webhook

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -458,6 +458,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 		found, foundErr := p.checkIfConfiguredWebhookExists(ctx, githubClient, repo, owner)
 		if foundErr != nil {
 			if strings.Contains(foundErr.Error(), "404 Not Found") {
+				// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorised to access webhooks.
 				return subOrgMsg
 			}
 			return errors.Wrap(foundErr, "failed to get the list of webhooks").Error()
@@ -497,6 +498,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 	found, err := p.checkIfConfiguredWebhookExists(ctx, githubClient, repo, owner)
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
+			// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorised to access webhooks.
 			return msg
 		}
 		return errors.Wrap(err, "failed to get the list of webhooks").Error()

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -458,7 +458,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 		found, foundErr := p.checkIfConfiguredWebhookExists(ctx, githubClient, repo, owner)
 		if foundErr != nil {
 			if strings.Contains(foundErr.Error(), "404 Not Found") {
-				// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorised to access webhooks.
+				// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorized to access webhooks.
 				return subOrgMsg
 			}
 			return errors.Wrap(foundErr, "failed to get the list of webhooks").Error()
@@ -498,7 +498,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 	found, err := p.checkIfConfiguredWebhookExists(ctx, githubClient, repo, owner)
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
-			// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorised to access webhooks.
+			// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorized to access webhooks.
 			return msg
 		}
 		return errors.Wrap(err, "failed to get the list of webhooks").Error()

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -459,13 +459,13 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 		if foundErr != nil {
 			if strings.Contains(foundErr.Error(), "404 Not Found") {
 				// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorized to access webhooks.
-				return subOrgMsg
+				return ""
 			}
 			return errors.Wrap(foundErr, "failed to get the list of webhooks").Error()
 		}
 
 		if !found {
-			subOrgMsg += errorNoWebhookFound
+			subOrgMsg = errorNoWebhookFound
 		}
 		return subOrgMsg
 	}
@@ -499,13 +499,13 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
 			// We are not returning an error here and just a subscription success message, as the above error condition occurs when the user is not authorized to access webhooks.
-			return msg
+			return ""
 		}
 		return errors.Wrap(err, "failed to get the list of webhooks").Error()
 	}
 
 	if !found {
-		msg += errorNoWebhookFound
+		msg = errorNoWebhookFound
 	}
 
 	return msg

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -366,8 +366,7 @@ func (p *Plugin) checkIfConfiguredWebhookExists(ctx context.Context, githubClien
 }
 
 func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs, parameters []string, userInfo *GitHubUserInfo) string {
-	const errorNoWebhookFound = "\nNo webhook was found for this repository or organization. To create one, enter the following slash command `/github setup webhook`"
-	const errorWebhookToUser = "\nNot able to get the list of webhooks. This feature is not available for subscription to a user."
+	const errorNoWebhookFound = "\n**Note:** No webhook was found for this repository or organization. To create one, enter the following slash command `/github setup webhook`"
 	subscriptionEvents := Features("pulls,issues,creates,deletes")
 	if len(parameters) == 0 {
 		return "Please specify a repository."
@@ -459,7 +458,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 		found, foundErr := p.checkIfConfiguredWebhookExists(ctx, githubClient, repo, owner)
 		if foundErr != nil {
 			if strings.Contains(foundErr.Error(), "404 Not Found") {
-				return errorWebhookToUser
+				return subOrgMsg
 			}
 			return errors.Wrap(foundErr, "failed to get the list of webhooks").Error()
 		}
@@ -498,7 +497,7 @@ func (p *Plugin) handleSubscribesAdd(_ *plugin.Context, args *model.CommandArgs,
 	found, err := p.checkIfConfiguredWebhookExists(ctx, githubClient, repo, owner)
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
-			return errorWebhookToUser
+			return msg
 		}
 		return errors.Wrap(err, "failed to get the list of webhooks").Error()
 	}


### PR DESCRIPTION
#### Summary
- Update subscription message when user is not authorized to access webhooks
- Update subscription message when there is no webhook present

#### Screenshots
- When user is not authorized to access webhooks
##### Before 
![image](https://github.com/mattermost/mattermost-plugin-github/assets/100013900/a75ac3cb-c462-43ea-9ab6-7e8f45980048)
##### After
![image](https://github.com/mattermost/mattermost-plugin-github/assets/100013900/bbc7308c-496d-4244-97eb-beda65d2e2d3)

- When there is no webhook present
##### Before 
![image](https://github.com/mattermost/mattermost-plugin-github/assets/100013900/a4b65482-5c73-4884-8830-f2e089260935)
##### After
![image](https://github.com/mattermost/mattermost-plugin-github/assets/100013900/0d394c04-027e-4f79-b192-60c29130d059)


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/715
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/732

#### What to test?
- Create a subscription with the user who doesn't have access to create webhooks and verify the post
- Similarly, create a subscription with no prior webhook present and verify the post