### PR TITLE
[GH-647]: Hide UsePreregisteredApplication on on-prem instances

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -25,7 +25,7 @@
                 "key": "UsePreregisteredApplication",
                 "display_name": "Use Preregistered OAuth Application:",
                 "type": "bool",
-                "help_text": "Set to false if using GitHub Enterprise. When true, instructs the plugin to use the preregistered GitHub OAuth application - application registration steps can be skipped. Requires [Chimera Proxy](https://github.com/mattermost/chimera) URL to be configured for the server. Cannot be used with GitHub enterprise. **This setting is intended to be used with Mattermost Cloud instances only.**",
+                "help_text": "Set to false if using GitHub Enterprise. When true, instructs the plugin to use the preregistered GitHub OAuth application - application registration steps can be skipped. Requires [Chimera Proxy](https://github.com/mattermost/chimera) URL to be configured for the server. Cannot be used with GitHub enterprise.",
                 "default": false,
                 "hosting": "cloud"
             },

--- a/plugin.json
+++ b/plugin.json
@@ -26,7 +26,8 @@
                 "display_name": "Use Preregistered OAuth Application:",
                 "type": "bool",
                 "help_text": "Set to false if using GitHub Enterprise. When true, instructs the plugin to use the preregistered GitHub OAuth application - application registration steps can be skipped. Requires [Chimera Proxy](https://github.com/mattermost/chimera) URL to be configured for the server. Cannot be used with GitHub enterprise. **This setting is intended to be used with Mattermost Cloud instances only.**",
-                "default": false
+                "default": false,
+                "hosting": "cloud"
             },
             {
                 "key": "GitHubOAuthClientID",


### PR DESCRIPTION
#### Summary
Using the hoisting property the UsePreregisteredApplication will only be on cloud servers.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-github/issues/647

### Testing Steps
The UsePreregisteredApplication will be hidden in on-prem servers and can only be seen in cloud instances.

