### PR TITLE
[GHG 654] Added mentions on sidebar buttons / rhs bar

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -66,6 +66,7 @@ type SidebarContent struct {
 	PRs         []*github.Issue         `json:"prs"`
 	Reviews     []*github.Issue         `json:"reviews"`
 	Assignments []*github.Issue         `json:"assignments"`
+	Mentions    []*github.Issue         `json:"mentions"`
 	Unreads     []*FilteredNotification `json:"unreads"`
 }
 
@@ -938,27 +939,30 @@ func (p *Plugin) createIssueComment(c *UserContext, w http.ResponseWriter, r *ht
 	p.writeJSON(w, result)
 }
 
-func (p *Plugin) getLHSData(c *UserContext) (reviewResp []*github.Issue, assignmentResp []*github.Issue, openPRResp []*github.Issue, err error) {
+func (p *Plugin) getLHSData(c *UserContext) (reviewResp []*github.Issue, assignmentResp []*github.Issue, openPRResp []*github.Issue, mentionsResp []*github.Issue, err error) {
 	graphQLClient := p.graphQLConnect(c.GHInfo)
 
-	reviewResp, assignmentResp, openPRResp, err = graphQLClient.GetLHSData(c.Context.Ctx)
+	reviewResp, assignmentResp, openPRResp, mentionsResp, err = graphQLClient.GetLHSData(c.Context.Ctx)
 	if err != nil {
-		return []*github.Issue{}, []*github.Issue{}, []*github.Issue{}, err
+		return []*github.Issue{}, []*github.Issue{}, []*github.Issue{}, []*github.Issue{}, err
 	}
 
-	return reviewResp, assignmentResp, openPRResp, nil
+	return reviewResp, assignmentResp, openPRResp, mentionsResp, nil
 }
 
 func (p *Plugin) getSidebarData(c *UserContext) (*SidebarContent, error) {
-	reviewResp, assignmentResp, openPRResp, err := p.getLHSData(c)
+	reviewResp, assignmentResp, openPRResp, mentionsResp, err := p.getLHSData(c)
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println(len(mentionsResp))
 
 	return &SidebarContent{
 		PRs:         openPRResp,
 		Assignments: assignmentResp,
 		Reviews:     reviewResp,
+		Mentions:    mentionsResp,
 		Unreads:     p.getUnreadsData(c),
 	}, nil
 }

--- a/server/plugin/graphql/lhs_query.go
+++ b/server/plugin/graphql/lhs_query.go
@@ -111,4 +111,13 @@ var mainQuery struct {
 			HasNextPage bool
 		}
 	} `graphql:"graphql: search(first:100, after:$openPrsCursor, query: $prOpenQueryArg, type: ISSUE)"`
+
+	Mentions struct {
+		IssueCount int
+		Nodes      []prSearchNodes
+		PageInfo   struct {
+			EndCursor   githubv4.String
+			HasNextPage bool
+		}
+	} `graphql:"mentions: search(first:100, after:$mentionsCursor, query: $prMentionsQueryArg, type: ISSUE)"`
 }

--- a/server/plugin/graphql/lhs_request.go
+++ b/server/plugin/graphql/lhs_request.go
@@ -13,38 +13,57 @@ const (
 	queryParamReviewsCursor     = "reviewsCursor"
 	queryParamAssignmentsCursor = "assignmentsCursor"
 	queryParamOpenPRsCursor     = "openPrsCursor"
+	queryParamMentionsCursor    = "mentionsCursor"
 
 	queryParamOpenPRQueryArg   = "prOpenQueryArg"
 	queryParamReviewPRQueryArg = "prReviewQueryArg"
 	queryParamAssigneeQueryArg = "assigneeQueryArg"
+	queryParamMentionsQueryArg = "prMentionsQueryArg"
 )
 
-func (c *Client) GetLHSData(ctx context.Context) ([]*github.Issue, []*github.Issue, []*github.Issue, error) {
+func (c *Client) GetLHSData(ctx context.Context) ([]*github.Issue, []*github.Issue, []*github.Issue, []*github.Issue, error) {
 	params := map[string]interface{}{
 		queryParamOpenPRQueryArg:    githubv4.String(fmt.Sprintf("author:%s is:pr is:%s archived:false", c.username, githubv4.PullRequestStateOpen)),
 		queryParamReviewPRQueryArg:  githubv4.String(fmt.Sprintf("review-requested:%s is:pr is:%s archived:false", c.username, githubv4.PullRequestStateOpen)),
 		queryParamAssigneeQueryArg:  githubv4.String(fmt.Sprintf("assignee:%s is:%s archived:false", c.username, githubv4.PullRequestStateOpen)),
+		queryParamMentionsQueryArg:  githubv4.String(fmt.Sprintf("mentions:%s is:%s is:pr archived:false", c.username, githubv4.PullRequestStateOpen)),
 		queryParamReviewsCursor:     (*githubv4.String)(nil),
 		queryParamAssignmentsCursor: (*githubv4.String)(nil),
 		queryParamOpenPRsCursor:     (*githubv4.String)(nil),
+		queryParamMentionsCursor:    (*githubv4.String)(nil),
 	}
 
 	if c.org != "" {
 		params[queryParamOpenPRQueryArg] = githubv4.String(fmt.Sprintf("org:%s %s", c.org, params[queryParamOpenPRQueryArg]))
 		params[queryParamReviewPRQueryArg] = githubv4.String(fmt.Sprintf("org:%s %s", c.org, params[queryParamReviewPRQueryArg]))
 		params[queryParamAssigneeQueryArg] = githubv4.String(fmt.Sprintf("org:%s %s", c.org, params[queryParamAssigneeQueryArg]))
+		params[queryParamMentionsQueryArg] = githubv4.String(fmt.Sprintf("org:%s %s", c.org, params[queryParamMentionsQueryArg]))
 	}
 
-	var resultReview, resultAssignee, resultOpenPR []*github.Issue
-	allReviewRequestsFetched, allAssignmentsFetched, allOpenPRsFetched := false, false, false
+	var resultReview, resultAssignee, resultOpenPR, resultMentions []*github.Issue
+	allReviewRequestsFetched, allAssignmentsFetched, allOpenPRsFetched, allMentionsFetched := false, false, false, false
 
 	for {
-		if allReviewRequestsFetched && allAssignmentsFetched && allOpenPRsFetched {
+		if allReviewRequestsFetched && allAssignmentsFetched && allOpenPRsFetched && allMentionsFetched {
 			break
 		}
 
 		if err := c.executeQuery(ctx, &mainQuery, params); err != nil {
-			return nil, nil, nil, errors.Wrap(err, "Not able to excute the query")
+			return nil, nil, nil, nil, errors.Wrap(err, "Not able to excute the query")
+		}
+
+		if !allMentionsFetched {
+			for i := range mainQuery.Mentions.Nodes {
+				resp := mainQuery.Mentions.Nodes[i]
+				pr := getPR(&resp)
+				resultMentions = append(resultMentions, pr)
+			}
+
+			if !mainQuery.Mentions.PageInfo.HasNextPage {
+				allMentionsFetched = true
+			}
+
+			params[queryParamMentionsCursor] = githubv4.NewString(mainQuery.Mentions.PageInfo.EndCursor)
 		}
 
 		if !allReviewRequestsFetched {
@@ -90,7 +109,7 @@ func (c *Client) GetLHSData(ctx context.Context) ([]*github.Issue, []*github.Iss
 		}
 	}
 
-	return resultReview, resultAssignee, resultOpenPR, nil
+	return resultReview, resultAssignee, resultOpenPR, resultMentions, nil
 }
 
 func getPR(prResp *prSearchNodes) *github.Issue {

--- a/webapp/src/components/sidebar_buttons/index.js
+++ b/webapp/src/components/sidebar_buttons/index.js
@@ -15,6 +15,7 @@ function mapStateToProps(state) {
     return {
         connected: state[`plugins-${pluginId}`].connected,
         clientId: state[`plugins-${pluginId}`].clientId,
+        mentions: state[`plugins-${pluginId}`].sidebarContent.mentions,
         reviews: state[`plugins-${pluginId}`].sidebarContent.reviews,
         yourPrs: state[`plugins-${pluginId}`].sidebarContent.prs,
         yourAssignments: state[`plugins-${pluginId}`].sidebarContent.assignments,

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -164,7 +164,7 @@ export default class SidebarButtons extends React.PureComponent {
                         onClick={() => this.openRHS(RHSStates.MENTIONS)}
                         style={button}
                     >
-                        <i className='fa fa-commenting'/>
+                        <i className='fa fa-comment-o'/>
                         {' ' + mentions.length}
                     </a>
                 </OverlayTrigger>

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -14,6 +14,7 @@ export default class SidebarButtons extends React.PureComponent {
         connected: PropTypes.bool,
         clientId: PropTypes.string,
         enterpriseURL: PropTypes.string,
+        mentions: PropTypes.arrayOf(PropTypes.object),
         reviews: PropTypes.arrayOf(PropTypes.object),
         unreads: PropTypes.arrayOf(PropTypes.object),
         yourPrs: PropTypes.arrayOf(PropTypes.object),
@@ -117,6 +118,7 @@ export default class SidebarButtons extends React.PureComponent {
             return null;
         }
 
+        const mentions = this.props.mentions || [];
         const reviews = this.props.reviews || [];
         const yourPrs = this.props.yourPrs || [];
         const unreads = this.props.unreads || [];
@@ -152,6 +154,21 @@ export default class SidebarButtons extends React.PureComponent {
                         {' ' + yourPrs.length}
                     </a>
                 </OverlayTrigger>
+
+                <OverlayTrigger
+                    key='githubMentionsLink'
+                    placement={placement}
+                    overlay={<Tooltip id='mentionTooltip'>{'Mentions on Pull Requests'}</Tooltip>}
+                >
+                    <a
+                        onClick={() => this.openRHS(RHSStates.MENTIONS)}
+                        style={button}
+                    >
+                        <i className='fa fa-commenting'/>
+                        {' ' + mentions.length}
+                    </a>
+                </OverlayTrigger>
+
                 <OverlayTrigger
                     key='githubReviewsLink'
                     placement={placement}

--- a/webapp/src/components/sidebar_right/index.jsx
+++ b/webapp/src/components/sidebar_right/index.jsx
@@ -11,11 +11,12 @@ import {getSidebarData} from 'src/selectors';
 import SidebarRight from './sidebar_right.jsx';
 
 function mapStateToProps(state) {
-    const {username, reviews, yourPrs, yourAssignments, unreads, enterpriseURL, org, rhsState} = getSidebarData(state);
+    const {username, mentions, reviews, yourPrs, yourAssignments, unreads, enterpriseURL, org, rhsState} = getSidebarData(state);
     return {
         username,
         reviews,
         yourPrs,
+        mentions,
         yourAssignments,
         unreads,
         enterpriseURL,

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -68,6 +68,7 @@ export default class SidebarRight extends React.PureComponent {
         username: PropTypes.string,
         org: PropTypes.string,
         enterpriseURL: PropTypes.string,
+        mentions: PropTypes.arrayOf(PropTypes.object),
         reviews: PropTypes.arrayOf(PropTypes.object),
         unreads: PropTypes.arrayOf(PropTypes.object),
         yourPrs: PropTypes.arrayOf(PropTypes.object),
@@ -103,7 +104,7 @@ export default class SidebarRight extends React.PureComponent {
     render() {
         const baseURL = this.props.enterpriseURL ? this.props.enterpriseURL : 'https://github.com';
         const orgQuery = this.props.org ? '+org%3A' + this.props.org : '';
-        const {yourPrs, reviews, unreads, yourAssignments, username, rhsState} = this.props;
+        const {yourPrs, mentions, reviews, unreads, yourAssignments, username, rhsState} = this.props;
 
         let title = '';
         let githubItems = [];
@@ -115,6 +116,13 @@ export default class SidebarRight extends React.PureComponent {
             githubItems = yourPrs;
             title = 'Your Open Pull Requests';
             listUrl = baseURL + '/pulls?q=is%3Aopen+is%3Apr+author%3A' + username + '+archived%3Afalse' + orgQuery;
+
+            break;
+        case RHSStates.MENTIONS:
+
+            githubItems = mentions;
+            title = 'Your mentions';
+            listUrl = baseURL + '/pulls?q=is%3Aopen+is%3Apr+mentions%3A' + username + '+archived%3Afalse' + orgQuery;
 
             break;
         case RHSStates.REVIEWS:

--- a/webapp/src/constants/index.js
+++ b/webapp/src/constants/index.js
@@ -10,4 +10,5 @@ export const RHSStates = {
     REVIEWS: 'reviews',
     UNREADS: 'unreads',
     ASSIGNMENTS: 'assignments',
+    MENTIONS: 'mentions',
 };

--- a/webapp/src/reducers/index.js
+++ b/webapp/src/reducers/index.js
@@ -91,6 +91,7 @@ const defaultSidebarContent = {
     prs: [],
     assignments: [],
     unreads: [],
+    mentions: [],
 };
 
 function sidebarContent(state = defaultSidebarContent, action) {

--- a/webapp/src/selectors.js
+++ b/webapp/src/selectors.js
@@ -52,9 +52,10 @@ function mapPrsToDetails(prs, details) {
 export const getSidebarData = createSelector(
     getPluginState,
     (pluginState) => {
-        const {username, sidebarContent, reviewDetails, yourPrDetails, organization, rhsState} = pluginState;
+        const {username, mentionsDetails, sidebarContent, reviewDetails, yourPrDetails, organization, rhsState} = pluginState;
         return {
             username,
+            mentions: mapPrsToDetails(sidebarContent.mentions || emptyArray, mentionsDetails),
             reviews: mapPrsToDetails(sidebarContent.reviews || emptyArray, reviewDetails),
             yourPrs: mapPrsToDetails(sidebarContent.prs || emptyArray, yourPrDetails),
             yourAssignments: sidebarContent.assignments || emptyArray,


### PR DESCRIPTION
Closes #654 

Summary:
Added mention icon and associated information in the RHS bar for the mentions in PRs as suggested in the issue. 

1. Server side changes include additional mentions graphql search query.
2. Webapp changes includes the mentions on the github sidebar buttons + sidebar right

Changes looks like:
![image](https://github.com/mattermost/mattermost-plugin-github/assets/32754336/11806cfc-cd5e-4705-88cf-44c4b1a8141b)
![image](https://github.com/mattermost/mattermost-plugin-github/assets/32754336/98a01086-8da1-4719-99bc-d7fa2f18747d)
![image](https://github.com/mattermost/mattermost-plugin-github/assets/32754336/0dd346fc-dc1c-407a-870a-e07e7273c769)


