### PR TITLE
fix message parse error on `pull_reviews`

### DIFF
--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -303,9 +303,9 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 
 	template.Must(masterTemplate.New("pullRequestReviewEvent").Funcs(funcMap).Parse(`
 {{template "repo" .GetRepo}} {{template "user" .GetSender}}
-{{- if eq .GetReview.GetState "APPROVED"}} approved
-{{- else if eq .GetReview.GetState "COMMENTED"}} commented on
-{{- else if eq .GetReview.GetState "CHANGES_REQUESTED"}} requested changes on
+{{- if eq .GetReview.GetState "approved"}} approved
+{{- else if eq .GetReview.GetState "commented"}} commented on
+{{- else if eq .GetReview.GetState "changes_requested"}} requested changes on
 {{- end }} {{template "pullRequest" .GetPullRequest}}:
 
 {{.Review.GetBody | replaceAllGitHubUsernames}}

--- a/server/plugin/template_test.go
+++ b/server/plugin/template_test.go
@@ -924,7 +924,7 @@ Excited to see git-get-head land!
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
-				State: sToP("APPROVED"),
+				State: sToP("approved"),
 				Body:  sToP("Excited to see git-get-head land!"),
 			},
 		})
@@ -944,7 +944,7 @@ Excited to see git-get-head land!
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
-				State: sToP("COMMENTED"),
+				State: sToP("commented"),
 				Body:  sToP("Excited to see git-get-head land!"),
 			},
 		})
@@ -964,7 +964,7 @@ Excited to see git-get-head land!
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
-				State: sToP("CHANGES_REQUESTED"),
+				State: sToP("changes_requested"),
 				Body:  sToP("Excited to see git-get-head land!"),
 			},
 		})
@@ -985,7 +985,7 @@ Excited to see git-get-head land!
 			PullRequest: &pullRequest,
 			Sender:      &user,
 			Review: &github.PullRequestReview{
-				State: sToP("APPROVED"),
+				State: sToP("approved"),
 				Body:  sToP("Excited to see git-get-head land!\n" + gitHubMentions),
 			},
 		})

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -866,10 +866,10 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 		return
 	}
 
-	switch strings.ToUpper(event.GetReview().GetState()) {
-	case "APPROVED":
-	case "COMMENTED":
-	case "CHANGES_REQUESTED":
+	switch event.GetReview().GetState() {
+	case "approved":
+	case "commented":
+	case "changes_requested":
 	default:
 		p.client.Log.Debug("Unhandled review state", "state", event.GetReview().GetState())
 		return

--- a/webapp/src/components/sidebar_right/github_items.tsx
+++ b/webapp/src/components/sidebar_right/github_items.tsx
@@ -405,7 +405,7 @@ function getReviewText(item: Item, style: any, secondLine: boolean) {
             return false;
         }
 
-        if (v.state === 'COMMENTED' || v.state === 'DISMISSED') {
+        if (v.state === 'commented' || v.state === 'dismissed') {
             return false;
         }
 
@@ -418,14 +418,14 @@ function getReviewText(item: Item, style: any, secondLine: boolean) {
     });
 
     const approved = lastReviews.reduce((accum: number, cur: Review) => {
-        if (cur.state === 'APPROVED') {
+        if (cur.state === 'approved') {
             return accum + 1;
         }
         return accum;
     }, 0);
 
     const changesRequested = lastReviews.reduce((accum: number, cur: Review) => {
-        if (cur.state === 'CHANGES_REQUESTED') {
+        if (cur.state === 'changes_requested') {
             return accum + 1;
         }
         return accum;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fix the problem that plugin subscribed `pull_reviews` didn't show the state of pr review.


#### Description
The plugin didn't show the status of pr review. When I checked the code, I found #689 that makes the state to uppercase for switch-case statement. However, on `renderTemplate`, Its if statement is using the state with lowercase so `renderTemplate` can't get the state and can't parse properly. Then I modified states to lowercase and check it w/ `make test`

#### Reproduce
1. Subscribe the repository with `/github subscriptions add <owner>/<repo> --features pull_reviews` on some channel.
2. Make PR on the repository.
3. Submit comment on the PR.
4. Check the message on the channel.

#### Problem
| AS IS | TO BE |
| --- | --- |
| [owner/repo] @foo pr-title:<br><br>Lorem ipsum... | [owner/repo] @foo approved pr-title:<br><br>Lorem ipsum... 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
NONE (under 20 lines of code change)