### PR TITLE
[GH-744] Add --include-only-org-members flag for channel subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ When you’ve tested the plugin and confirmed it’s working, notify your team s
   - The following flags are supported:
      - `--features`: comma-delimited list of one or more of: issues, pulls, pulls_merged, pulls_created, pushes, creates, deletes, issue_creations, issue_comments, pull_reviews, label:"labelname". Defaults to pulls,issues,creates,deletes.
      - `--exclude-org-member`: events triggered by organization members will not be delivered. It will be locked to the organization provided in the plugin configuration and it will only work for users whose membership is public. Note that organization members and collaborators are not the same.
+     - `--include-only-org-members`: events triggered only by organization members will be delivered. It will be locked to the organization provided in the plugin configuration and it will only work for users whose membership is public. Note that organization members and collaborators are not the same.
      - `--render-style`: notifications will be delivered in the specified style (for example, the body of a pull request will not be displayed). Supported
      values are `collapsed`, `skip-body` or `default` (same as omitting the flag).
      - `--exclude`: comma-separated list of the repositories to exclude from getting the subscription notifications like `mattermost/mattermost-server`. Only supported for subscriptions to an organization.

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -907,6 +907,16 @@ func getAutocompleteData(config *Configuration) *model.AutocompleteData {
 				HelpText: "Include posts from members of the configured organization",
 			},
 		})
+		subscriptionsAdd.AddNamedStaticListArgument("include-only-org-members", "Events triggered only by organization members will be delivered (the organization config should be set, otherwise this flag has not effect)", false, []model.AutocompleteListItem{
+			{
+				Item:     "true",
+				HelpText: "Include posts only from members of the configured organization",
+			},
+			{
+				Item:     "false",
+				HelpText: "Include posts from members and collaborators of the configured organization",
+			},
+		})
 	}
 
 	subscriptionsAdd.AddNamedStaticListArgument("render-style", "Determine the rendering style of various notifications.", false, []model.AutocompleteListItem{

--- a/server/plugin/subscriptions_test.go
+++ b/server/plugin/subscriptions_test.go
@@ -1,8 +1,11 @@
 package plugin
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/go-github/v54/github"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -115,6 +118,105 @@ func TestPlugin_GetSubscriptionsByChannel(t *testing.T) {
 			CheckError(t, tt.wantErr, err)
 
 			assert.Equal(t, tt.want, got, "they should be same")
+		})
+	}
+}
+
+func TestAddFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   SubscriptionFlags
+		flag    string
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "IncludeOnlyOrgMembers flag is parsed",
+			flags:   SubscriptionFlags{},
+			flag:    "include-only-org-members",
+			value:   "true",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "IncludeOnlyOrgMembers flag cannot be parsed",
+			flags:   SubscriptionFlags{},
+			flag:    "include-only-org-members",
+			value:   "test",
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+
+			err := tt.flags.AddFlag(tt.flag, tt.value)
+			CheckError(t, tt.wantErr, err)
+			assert.Equal(t, tt.flags.IncludeOnlyOrgMembers, tt.want)
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags SubscriptionFlags
+		flag  string
+		value string
+		want  string
+	}{
+		{
+			name:  "Return --include-only-org-members string",
+			flags: SubscriptionFlags{},
+			flag:  "include-only-org-members",
+			value: "true",
+			want:  "--include-only-org-members true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+			_ = tt.flags.AddFlag(tt.flag, tt.value)
+			got := tt.flags.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSubscribe(t *testing.T) {
+	tests := []struct {
+		name   string
+		flags  SubscriptionFlags
+		plugin *Plugin
+		errMsg string
+	}{
+		{
+			name:   "Return error if GitHub organization is not set when --include-only-org-members flag is true",
+			flags:  SubscriptionFlags{IncludeOnlyOrgMembers: true},
+			plugin: NewPlugin(),
+			errMsg: "Unable to set --include-only-org-members flag. The GitHub plugin is not locked to a single organization.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+			err := tt.plugin.Subscribe(
+				context.Background(),
+				github.NewClient(nil),
+				model.NewId(),
+				"test-owner",
+				"test-repo",
+				model.NewId(),
+				"test-features",
+				tt.flags,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
 }

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -411,6 +411,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 		"    	* `label:<labelname>` - limit pull request and issue events to only this label. Must include `pulls` or `issues` in feature list when using a label.\n" +
 		"    	* Defaults to `pulls,issues,creates,deletes`\n\n" +
 		"    * `--exclude-org-member` - events triggered by organization members will not be delivered (the GitHub organization config should be set, otherwise this flag has not effect)\n" +
+		"    * `--include-only-org-members` - events triggered only by organization members will be delivered (the GitHub organization config should be set, otherwise this flag has not effect)\n" +
 		"    * `--render-style` - notifications will be delivered in the specified style (for example, the body of a pull request will not be displayed). Supported values are `collapsed`, `skip-body` or `default` (same as omitting the flag).\n" +
 		"* `/github subscriptions delete owner[/repo]` - Unsubscribe the current channel from a repository\n" +
 		"* `/github me` - Display the connected GitHub account\n" +

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -345,6 +345,20 @@ func (p *Plugin) excludeConfigOrgMember(user *github.User, subscription *Subscri
 	return p.isUserOrganizationMember(githubClient, user, organization)
 }
 
+func (p *Plugin) includeOnlyConfigOrgMembers(user *github.User, subscription *Subscription) bool {
+	if !subscription.IncludeOnlyOrgMembers() {
+		return false
+	}
+
+	githubClient, err := p.GetGitHubClient(context.Background(), subscription.CreatorID)
+	if err != nil {
+		p.client.Log.Warn("Failed to get user info", "error", err.Error())
+		return false
+	}
+
+	return !p.isUserOrganizationMember(githubClient, user, p.getConfiguration().GitHubOrg)
+}
+
 func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 	repo := event.GetRepo()
 
@@ -397,6 +411,10 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
 			continue
 		}
 
@@ -598,6 +616,10 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 			continue
 		}
 
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
+			continue
+		}
+
 		renderedMessage, err := renderTemplate(issueTemplate, GetEventWithRenderConfig(event, sub))
 		if err != nil {
 			p.client.Log.Warn("Failed to render template", "error", err.Error())
@@ -680,6 +702,10 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 			continue
 		}
 
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
+			continue
+		}
+
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
 			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
@@ -718,6 +744,10 @@ func (p *Plugin) postCreateEvent(event *github.CreateEvent) {
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
 			continue
 		}
 
@@ -761,6 +791,10 @@ func (p *Plugin) postDeleteEvent(event *github.DeleteEvent) {
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
 			continue
 		}
 
@@ -813,6 +847,10 @@ func (p *Plugin) postIssueCommentEvent(event *github.IssueCommentEvent) {
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
 			continue
 		}
 
@@ -901,6 +939,10 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 			continue
 		}
 
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
+			continue
+		}
+
 		label := sub.Label()
 
 		contained := false
@@ -959,6 +1001,10 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
 			continue
 		}
 
@@ -1368,6 +1414,10 @@ func (p *Plugin) postStarEvent(event *github.StarEvent) {
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {
+			continue
+		}
+
+		if p.includeOnlyConfigOrgMembers(event.GetSender(), sub) {
 			continue
 		}
 

--- a/server/plugin/webhook_test.go
+++ b/server/plugin/webhook_test.go
@@ -1,0 +1,127 @@
+package plugin
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"golang.org/x/oauth2"
+
+	"github.com/google/go-github/v54/github"
+	"github.com/stretchr/testify/assert"
+)
+
+const webhookSecret = "whsecret"
+const orgMember = "org-member"
+const orgCollaborator = "org-collaborator"
+const gitHubOrginization = "test-org"
+
+func newPlugin(userID string, gitHubURL string) *Plugin {
+	p := NewPlugin()
+	p.initializeAPI()
+	p.SetDriver(&plugintest.Driver{})
+	p.store = &pluginapi.MemoryStore{}
+	token, _ := generateSecret()
+	encryptionKey, _ := generateSecret()
+	encryptedToken, _ := encrypt([]byte(encryptionKey), token)
+	_, _ = p.store.Set(userID+githubTokenKey, GitHubUserInfo{
+		UserID: userID,
+		Token: &oauth2.Token{
+			AccessToken: encryptedToken,
+		},
+	})
+	p.setConfiguration(&Configuration{
+		EncryptionKey:       encryptionKey,
+		GitHubOrg:           gitHubOrginization,
+		WebhookSecret:       webhookSecret,
+		EnterpriseBaseURL:   gitHubURL,
+		EnterpriseUploadURL: gitHubURL,
+	})
+
+	_ = p.AddSubscription(
+		gitHubOrginization+"/test-repo",
+		&Subscription{
+			ChannelID: "1",
+			CreatorID: userID,
+			Features:  Features(strings.Join([]string{featureIssues, featureIssueCreation}, ",")),
+			Flags:     SubscriptionFlags{IncludeOnlyOrgMembers: true},
+		},
+	)
+
+	return p
+}
+
+func mockGitHubServer(user string) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("/api/v3/orgs/%v/members/%v", gitHubOrginization, user) {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+
+		if user == orgMember {
+			w.WriteHeader(http.StatusNoContent)
+		} else if user == orgCollaborator {
+			w.WriteHeader(http.StatusFound)
+		}
+	}))
+
+	return ts
+}
+
+func TestIncludeOnlyOrgMembers(t *testing.T) {
+	tests := []struct {
+		name         string
+		user         github.User
+		subscription Subscription
+		expectWarn   bool
+		want         bool
+	}{
+		{
+			name: "IncludeOnlyOrgMembers flag is false",
+			user: github.User{
+				Login: github.String(orgMember),
+			},
+			subscription: Subscription{
+				Flags: SubscriptionFlags{IncludeOnlyOrgMembers: false},
+			},
+			expectWarn: false,
+			want:       false,
+		},
+		{
+			name: "Failed to get GitHub Client",
+			user: github.User{
+				Login: github.String(orgMember),
+			},
+			subscription: Subscription{
+				CreatorID: model.NewId(),
+				Flags:     SubscriptionFlags{IncludeOnlyOrgMembers: true},
+			},
+			expectWarn: true,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+			user := *tt.user.Login
+			server := mockGitHubServer(user)
+			gitHubPlugin := newPlugin(model.NewId(), server.URL)
+			api := plugintest.NewAPI(t)
+			if tt.expectWarn {
+				api.On("LogWarn", mock.AnythingOfType("string"), "error", mock.AnythingOfType("string")).Return(nil)
+			}
+			gitHubPlugin.SetAPI(api)
+			gitHubPlugin.client = pluginapi.NewClient(gitHubPlugin.API, gitHubPlugin.Driver)
+
+			got := gitHubPlugin.includeOnlyConfigOrgMembers(&tt.user, &tt.subscription)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
This PR adds `--include-only-org-members` flag for channel subscriptions

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-github/issues/744

