### PR TITLE
Don't return an 500 error when the plugin is not configured

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -184,7 +184,7 @@ func (p *Plugin) checkConfigured(next http.Handler) http.Handler {
 		config := p.getConfiguration()
 
 		if err := config.IsValid(); err != nil {
-			http.Error(w, "This plugin is not configured.", http.StatusNotImplemented)
+			http.Error(w, "This plugin is not configured.", http.StatusUnprocessableEntity)
 			return
 		}
 


### PR DESCRIPTION
#### Summary
https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content states
> The 422 (Unprocessable Content) status code indicates that the server understands the content type of the request content (hence a [415 (Unsupported Media Type)](https://www.rfc-editor.org/rfc/rfc9110.html#status.415) status code is inappropriate), and the syntax of the request content is correct, but it was unable to process the contained instructions. For example, this status code can be sent if an XML request content contains well-formed (i.e., syntactically correct), but semantically erroneous XML instructions.

#### Ticket Link
https://hub.mattermost.com/private-core/pl/1jafc1wuftnmzygdittxd73nia

