### PR TITLE
[MM-593] Added escape characters to user, repo and path in permalink preview

### DIFF
--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -298,9 +298,9 @@ func isInsideLink(msg string, index int) bool {
 
 // getCodeMarkdown returns the constructed markdown for a permalink.
 func getCodeMarkdown(user, repo, repoPath, word, lines string, isTruncated bool) string {
-	user = strings.Replace(user, "_", "\\_", -1)
-	repo = strings.Replace(repo, "_", "\\_", -1)
-	repoPath = strings.Replace(repoPath, "_", "\\_", -1)
+	user = strings.ReplaceAll(user, "_", "\\_")
+	repo = strings.ReplaceAll(repo, "_", "\\_")
+	repoPath = strings.ReplaceAll(repoPath, "_", "\\_")
 	final := fmt.Sprintf("\n[%s/%s/%s](%s)\n", user, repo, repoPath, word)
 	ext := path.Ext(repoPath)
 	// remove the preceding dot

--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -298,6 +298,9 @@ func isInsideLink(msg string, index int) bool {
 
 // getCodeMarkdown returns the constructed markdown for a permalink.
 func getCodeMarkdown(user, repo, repoPath, word, lines string, isTruncated bool) string {
+	user = strings.Replace(user, "_", "\\_", -1)
+	repo = strings.Replace(repo, "_", "\\_", -1)
+	repoPath = strings.Replace(repoPath, "_", "\\_", -1)
 	final := fmt.Sprintf("\n[%s/%s/%s](%s)\n", user, repo, repoPath, word)
 	ext := path.Ext(repoPath)
 	// remove the preceding dot


### PR DESCRIPTION
#### Summary
- Added escape characters to user, repo and path in permalink preview to avoid repo/file name being rendered as markdown.

#### Screenshots
![image](https://github.com/user-attachments/assets/acb2b5b8-9d0f-4afd-9b4c-0369d8812b2e)

#### How to test?
1. Connect your github account.
1. Paste the permalink of a file/repo with the name containing markdown pattern (Ex. \_\_abc\_\_ will be rendered as __abc__ in markdown)

#### Ticket Link
Fixes #793 

