### PR TITLE
[GH-802] Added config setting for getting notification for draft PRs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -124,6 +124,13 @@
                 "type": "bool",
                 "help_text": "In 'Pushes' event notification, show commit author instead of commit committer.",
                 "default": false
+            },
+            {
+                "key": "GetNotificationForDraftPRs",
+                "display_name": "Get Notification for Draft PRs:",
+                "type": "bool",
+                "help_text": "When set to 'true' you will get notification with less details when a draft PR is created and a notification with complete details when they are marked as ready for review.",
+                "default": false
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."

--- a/server/plugin/configuration.go
+++ b/server/plugin/configuration.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	EnableWebhookEventLogging      bool   `json:"enablewebhookeventlogging"`
 	UsePreregisteredApplication    bool   `json:"usepreregisteredapplication"`
 	ShowAuthorInCommitNotification bool   `json:"showauthorincommitnotification"`
+	GetNotificationForDraftPRs     bool   `json:"getnotificationfordraftprs"`
 }
 
 func (c *Configuration) ToMap() (map[string]interface{}, error) {

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -438,7 +438,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 
 		if action == actionOpened {
 			prNotificationType := "newPR"
-			if isPRInDraftState {
+			if isPRInDraftState && p.configuration.GetNotificationForDraftPRs {
 				prNotificationType = "newDraftPR"
 			}
 			newPRMessage, err := renderTemplate(prNotificationType, GetEventWithRenderConfig(event, sub))
@@ -460,7 +460,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			post.Message = p.sanitizeDescription(reopenedPRMessage)
 		}
 
-		if action == actionMarkedReadyForReview {
+		if action == actionMarkedReadyForReview && p.configuration.GetNotificationForDraftPRs {
 			markedReadyToReviewPRMessage, err := renderTemplate("markedReadyToReviewPR", GetEventWithRenderConfig(event, sub))
 			if err != nil {
 				p.client.Log.Warn("Failed to render template", "error", err.Error())


### PR DESCRIPTION
#### Summary
- Added config setting for getting notification for draft PRs

#### Screenshot:
![image](https://github.com/user-attachments/assets/fd3715bb-abf4-4664-b316-4fbf1eb34132)

#### What to test:
1. When setting is disabled:
- Getting a single for notification regardless of the PR state (i.e. draft/ready).

2. When setting is enable:
- Getting a notification with less details when a draft PR is created.
- Getting a notification with complete details when a draft PR is marked as ready for review.
- Getting a notification with complete details for a normal PR.

#### How to test:
1. Connect you github account.
2. Create subscription for "pulls" in desired channel
3. Trigger the desired event from github.

#### Ticket Link
Fixes #802 

