### PR TITLE
[MM-805]: Removed the 'Emoji is not supported by Github' log from the reactions hooks

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -340,7 +340,6 @@ func (p *Plugin) getPostPropsForReaction(reaction *model.Reaction) (org, repo st
 func (p *Plugin) ReactionHasBeenAdded(c *plugin.Context, reaction *model.Reaction) {
 	githubEmoji := p.emojiMap[reaction.EmojiName]
 	if githubEmoji == "" {
-		p.client.Log.Warn("Emoji is not supported by Github", "Emoji", reaction.EmojiName)
 		return
 	}
 
@@ -384,7 +383,6 @@ func (p *Plugin) ReactionHasBeenAdded(c *plugin.Context, reaction *model.Reactio
 func (p *Plugin) ReactionHasBeenRemoved(c *plugin.Context, reaction *model.Reaction) {
 	githubEmoji := p.emojiMap[reaction.EmojiName]
 	if githubEmoji == "" {
-		p.client.Log.Warn("Emoji is not supported by Github", "Emoji", reaction.EmojiName)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Removed the log 'Emoji is not supported by Github' as it was coming every time any user added or removed the reaction on the post.

#### Ticket Link
#805 

