### PR TITLE
[MM-60676] Fix incorrect callback URL in setup flow

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -817,9 +818,7 @@ func (p *Plugin) searchIssues(c *UserContext, w http.ResponseWriter, r *http.Req
 }
 
 func (p *Plugin) getPermaLink(postID string) string {
-	siteURL := *p.client.Configuration.GetConfig().ServiceSettings.SiteURL
-
-	return fmt.Sprintf("%v/_redirect/pl/%v", siteURL, postID)
+	return getSiteURL(p.client) + "/" + path.Join("_redirect", "pl", postID)
 }
 
 func getFailReason(code int, repo string, username string) string {

--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -337,7 +337,7 @@ func (p *Plugin) checkIfConfiguredWebhookExists(ctx context.Context, githubClien
 	opt := &github.ListOptions{
 		PerPage: PerPageValue,
 	}
-	siteURL := *p.client.Configuration.GetConfig().ServiceSettings.SiteURL
+	siteURL := getSiteURL(p.client)
 
 	for {
 		var githubHooks []*github.Hook
@@ -804,8 +804,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	}
 
 	if action == "connect" {
-		siteURL := p.client.Configuration.GetConfig().ServiceSettings.SiteURL
-		if siteURL == nil {
+		pluginURL := getPluginURL(p.client)
+		if pluginURL == "" {
 			p.postCommandResponse(args, "Encountered an error connecting to GitHub.")
 			return &model.CommandResponse{}, nil
 		}
@@ -834,7 +834,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			qparams = "?private=true"
 		}
 
-		msg := fmt.Sprintf("[Click here to link your GitHub account.](%s/plugins/%s/oauth/connect%s)", *siteURL, Manifest.Id, qparams)
+		msg := fmt.Sprintf("[Click here to link your GitHub account.](%s/oauth/connect%s)", pluginURL, qparams)
 		p.postCommandResponse(args, msg)
 		return &model.CommandResponse{}, nil
 	}

--- a/server/plugin/flows.go
+++ b/server/plugin/flows.go
@@ -498,7 +498,7 @@ You must first register the Mattermost GitHub Plugin as an authorized OAuth app.
 		"3. Select **Register application**\n"+
 		"4. Select **Generate a new client secret**.\n"+
 		"5. If prompted, complete 2FA.",
-		fm.pluginID,
+		getPluginURL(fm.client),
 	)
 
 	return flow.NewStep(stepOAuthInfo).
@@ -597,7 +597,7 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 
 func (fm *FlowManager) stepOAuthConnect() flow.Step {
 	connectPretext := "##### :white_check_mark: Step {{ if .UsePreregisteredApplication }}1{{ else }}2{{ end }}: Connect your GitHub account"
-	connectURL := fmt.Sprintf("%s/oauth/connect", fm.pluginID)
+	connectURL := fmt.Sprintf("%s/oauth/connect", getPluginURL(fm.client))
 	connectText := fmt.Sprintf("Go [here](%s) to connect your account.", connectURL)
 	return flow.NewStep(stepOAuthConnect).
 		WithText(connectText).
@@ -689,7 +689,7 @@ func (fm *FlowManager) submitWebhook(f *flow.Flow, submitted map[string]interfac
 		"content_type": "json",
 		"insecure_ssl": "0",
 		"secret":       config.WebhookSecret,
-		"url":          fmt.Sprintf("%s/webhook", fm.pluginID),
+		"url":          fmt.Sprintf("%s/webhook", getPluginURL(fm.client)),
 	}
 
 	hook := &github.Hook{

--- a/server/plugin/flows.go
+++ b/server/plugin/flows.go
@@ -486,6 +486,11 @@ func (fm *FlowManager) submitEnterpriseConfig(f *flow.Flow, submitted map[string
 }
 
 func (fm *FlowManager) stepOAuthInfo() flow.Step {
+	callbackURL, err := buildPluginURL(fm.client, "oauth", "complete")
+	if err != nil {
+		fm.client.Log.Warn("Failed to build callbackURL", "err", err)
+	}
+
 	oauthPretext := `
 ##### :white_check_mark: Step 1: Register an OAuth Application in GitHub
 You must first register the Mattermost GitHub Plugin as an authorized OAuth app.`
@@ -494,11 +499,11 @@ You must first register the Mattermost GitHub Plugin as an authorized OAuth app.
 		"2. Set the following values:\n"+
 		"	- Application name: `Mattermost GitHub Plugin - <your company name>`\n"+
 		"	- Homepage URL: `https://github.com/mattermost/mattermost-plugin-github`\n"+
-		"	- Authorization callback URL: `%s/oauth/complete`\n"+
+		"	- Authorization callback URL: `%s`\n"+
 		"3. Select **Register application**\n"+
 		"4. Select **Generate a new client secret**.\n"+
 		"5. If prompted, complete 2FA.",
-		getPluginURL(fm.client),
+		callbackURL,
 	)
 
 	return flow.NewStep(stepOAuthInfo).
@@ -597,7 +602,11 @@ func (fm *FlowManager) submitOAuthConfig(f *flow.Flow, submitted map[string]inte
 
 func (fm *FlowManager) stepOAuthConnect() flow.Step {
 	connectPretext := "##### :white_check_mark: Step {{ if .UsePreregisteredApplication }}1{{ else }}2{{ end }}: Connect your GitHub account"
-	connectURL := fmt.Sprintf("%s/oauth/connect", getPluginURL(fm.client))
+	connectURL, err := buildPluginURL(fm.client, "oauth", "connect")
+	if err != nil {
+		fm.client.Log.Warn("Failed to build connectURL", "err", err)
+	}
+
 	connectText := fmt.Sprintf("Go [here](%s) to connect your account.", connectURL)
 	return flow.NewStep(stepOAuthConnect).
 		WithText(connectText).
@@ -685,11 +694,16 @@ func (fm *FlowManager) submitWebhook(f *flow.Flow, submitted map[string]interfac
 
 	webhookEvents := []string{"create", "delete", "issue_comment", "issues", "pull_request", "pull_request_review", "pull_request_review_comment", "push", "star"}
 
+	webHookURL, err := buildPluginURL(fm.client, "webhook")
+	if err != nil {
+		fm.client.Log.Warn("Failed to build webHookURL", "err", err)
+	}
+
 	webhookConfig := map[string]interface{}{
 		"content_type": "json",
 		"insecure_ssl": "0",
 		"secret":       config.WebhookSecret,
-		"url":          fmt.Sprintf("%s/webhook", getPluginURL(fm.client)),
+		"url":          webHookURL,
 	}
 
 	hook := &github.Hook{

--- a/server/plugin/graphql/client.go
+++ b/server/plugin/graphql/client.go
@@ -3,7 +3,6 @@ package graphql
 import (
 	"context"
 	"net/url"
-	"path"
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/githubv4"
@@ -36,16 +35,14 @@ func NewClient(logger pluginapi.LogService, getOrganizations func() []string, to
 			getOrganizations: getOrganizations,
 		}
 	} else {
-		baseURL, err := url.Parse(enterpriseBaseURL)
+		baseURL, err := url.JoinPath(enterpriseBaseURL, "api", "graphql")
 		if err != nil {
-			logger.Debug("Not able to parse the URL", "error", err.Error())
+			logger.Debug("Not able to parse the enterprise URL", "error", err.Error())
 			return nil
 		}
 
-		baseURL.Path = path.Join(baseURL.Path, "api", "graphql")
-
 		client = Client{
-			client:           githubv4.NewEnterpriseClient(baseURL.String(), httpClient),
+			client:           githubv4.NewEnterpriseClient(baseURL, httpClient),
 			username:         username,
 			org:              orgName,
 			logger:           logger,

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -203,14 +202,17 @@ func getGitHubClient(authenticatedClient *http.Client, config *Configuration) (*
 	if config.EnterpriseBaseURL == "" || config.EnterpriseUploadURL == "" {
 		return github.NewClient(authenticatedClient), nil
 	}
+	baseURL, err := url.JoinPath(config.EnterpriseBaseURL, "api", "v3")
+	if err != nil {
+		return nil, err
+	}
 
-	baseURL, _ := url.Parse(config.EnterpriseBaseURL)
-	baseURL.Path = path.Join(baseURL.Path, "api", "v3")
+	uploadURL, err := url.JoinPath(config.EnterpriseUploadURL, "api", "v3")
+	if err != nil {
+		return nil, err
+	}
 
-	uploadURL, _ := url.Parse(config.EnterpriseUploadURL)
-	uploadURL.Path = path.Join(uploadURL.Path, "api", "v3")
-
-	client, err := github.NewEnterpriseClient(baseURL.String(), uploadURL.String(), authenticatedClient)
+	client, err := github.NewEnterpriseClient(baseURL, uploadURL, authenticatedClient)
 	if err != nil {
 		return nil, err
 	}
@@ -244,12 +246,12 @@ func (p *Plugin) setDefaultConfiguration() error {
 func (p *Plugin) OnActivate() error {
 	p.ensurePluginAPIClient()
 
-	siteURL := getSiteURL(p.client)
-	if siteURL == "" {
-		return errors.New("siteURL is not set. Please set it and restart the plugin")
+	_, err := getSiteURL(p.client)
+	if err != nil {
+		return err
 	}
 
-	err := p.setDefaultConfiguration()
+	err = p.setDefaultConfiguration()
 	if err != nil {
 		return errors.Wrap(err, "failed to set default configuration")
 	}
@@ -525,7 +527,7 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 	return post, ""
 }
 
-func (p *Plugin) getOAuthConfig(privateAllowed bool) *oauth2.Config {
+func (p *Plugin) getOAuthConfig(privateAllowed bool) (*oauth2.Config, error) {
 	config := p.getConfiguration()
 
 	repo := github.ScopePublicRepo
@@ -545,44 +547,54 @@ func (p *Plugin) getOAuthConfig(privateAllowed bool) *oauth2.Config {
 		baseURL = testOAuthServerURL + "/"
 	}
 
-	authURL, _ := url.Parse(baseURL)
-	tokenURL, _ := url.Parse(baseURL)
-
-	authURL.Path = path.Join(authURL.Path, "login", "oauth", "authorize")
-	tokenURL.Path = path.Join(tokenURL.Path, "login", "oauth", "access_token")
+	authURL, err := url.JoinPath(baseURL, "login", "oauth", "authorize")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build AuthURL")
+	}
+	tokenURL, err := url.JoinPath(baseURL, "login", "oauth", "access_token")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build TokenURL")
+	}
 
 	return &oauth2.Config{
 		ClientID:     config.GitHubOAuthClientID,
 		ClientSecret: config.GitHubOAuthClientSecret,
 		Scopes:       scopes,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:   authURL.String(),
-			TokenURL:  tokenURL.String(),
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
 			AuthStyle: oauth2.AuthStyleInHeader,
 		},
-	}
+	}, nil
 }
 
-func (p *Plugin) getOAuthConfigForChimeraApp(scopes []string) *oauth2.Config {
+func (p *Plugin) getOAuthConfigForChimeraApp(scopes []string) (*oauth2.Config, error) {
 	baseURL := fmt.Sprintf("%s/v1/github/%s", p.chimeraURL, chimeraGitHubAppIdentifier)
-	authURL, _ := url.Parse(baseURL)
-	tokenURL, _ := url.Parse(baseURL)
 
-	authURL.Path = path.Join(authURL.Path, "oauth", "authorize")
-	tokenURL.Path = path.Join(tokenURL.Path, "oauth", "token")
-	redirectURL, _ := url.Parse(path.Join(getPluginURL(p.client), "oauth", "complete"))
+	authURL, err := url.JoinPath(baseURL, "oauth", "authorize")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build AuthURL")
+	}
+	tokenURL, err := url.JoinPath(baseURL, "oauth", "token")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build TokenURL")
+	}
+	redirectURL, err := buildPluginURL(p.client, "oauth", "token")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build RedirectURL")
+	}
 
 	return &oauth2.Config{
 		ClientID:     "placeholder",
 		ClientSecret: "placeholder",
 		Scopes:       scopes,
-		RedirectURL:  redirectURL.String(),
+		RedirectURL:  redirectURL,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:   authURL.String(),
-			TokenURL:  tokenURL.String(),
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
 			AuthStyle: oauth2.AuthStyleInHeader,
 		},
-	}
+	}, nil
 }
 
 type GitHubUserInfo struct {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -244,8 +244,8 @@ func (p *Plugin) setDefaultConfiguration() error {
 func (p *Plugin) OnActivate() error {
 	p.ensurePluginAPIClient()
 
-	siteURL := p.client.Configuration.GetConfig().ServiceSettings.SiteURL
-	if siteURL == nil || *siteURL == "" {
+	siteURL := getSiteURL(p.client)
+	if siteURL == "" {
 		return errors.New("siteURL is not set. Please set it and restart the plugin")
 	}
 
@@ -570,8 +570,7 @@ func (p *Plugin) getOAuthConfigForChimeraApp(scopes []string) *oauth2.Config {
 
 	authURL.Path = path.Join(authURL.Path, "oauth", "authorize")
 	tokenURL.Path = path.Join(tokenURL.Path, "oauth", "token")
-
-	redirectURL, _ := url.Parse(fmt.Sprintf("%s/plugins/github/oauth/complete", *p.client.Configuration.GetConfig().ServiceSettings.SiteURL))
+	redirectURL, _ := url.Parse(path.Join(getPluginURL(p.client), "oauth", "complete"))
 
 	return &oauth2.Config{
 		ClientID:     "placeholder",

--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -378,7 +378,7 @@ func buildPluginURL(client *pluginapi.Client, elem ...string) (string, error) {
 		return "", err
 	}
 
-	redirectURL, err := url.JoinPath(siteURL, append([]string{"foo", Manifest.Id}, elem...)...)
+	redirectURL, err := url.JoinPath(siteURL, append([]string{"plugins", Manifest.Id}, elem...)...)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to build pluginURL")
 	}

--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -372,17 +372,27 @@ func isValidURL(rawURL string) error {
 	return nil
 }
 
-func getPluginURL(client *pluginapi.Client) string {
-	return getSiteURL(client) + "/" + path.Join("plugins", Manifest.Id)
-}
-
-func getSiteURL(client *pluginapi.Client) string {
-	siteURL := client.Configuration.GetConfig().ServiceSettings.SiteURL
-	if siteURL == nil {
-		return ""
+func buildPluginURL(client *pluginapi.Client, elem ...string) (string, error) {
+	siteURL, err := getSiteURL(client)
+	if err != nil {
+		return "", err
 	}
 
-	return strings.TrimSuffix(*siteURL, "/")
+	redirectURL, err := url.JoinPath(siteURL, append([]string{"foo", Manifest.Id}, elem...)...)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to build pluginURL")
+	}
+
+	return redirectURL, nil
+}
+
+func getSiteURL(client *pluginapi.Client) (string, error) {
+	siteURL := client.Configuration.GetConfig().ServiceSettings.SiteURL
+	if siteURL == nil {
+		return "", errors.New("siteURL is not set. Please set it and restart the plugin")
+	}
+
+	return strings.TrimSuffix(*siteURL, "/"), nil
 }
 
 // lastN returns the last n characters of a string, with the rest replaced by *.

--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+
 	"github.com/google/go-github/v54/github"
 	"github.com/pkg/errors"
 )
@@ -368,6 +370,19 @@ func isValidURL(rawURL string) error {
 	}
 
 	return nil
+}
+
+func getPluginURL(client *pluginapi.Client) string {
+	return getSiteURL(client) + "/" + path.Join("plugins", Manifest.Id)
+}
+
+func getSiteURL(client *pluginapi.Client) string {
+	siteURL := client.Configuration.GetConfig().ServiceSettings.SiteURL
+	if siteURL == nil {
+		return ""
+	}
+
+	return strings.TrimSuffix(*siteURL, "/")
 }
 
 // lastN returns the last n characters of a string, with the rest replaced by *.


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-plugin-github/pull/811 introduced a regression: The callback URL shown as part of the setup flow was missing the SiteURl.

This PR fixes the issue. On top of that, it unifies the handling of the SiteURL using two helper methods. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60676
