### PR TITLE
Fix missing PR notifications when using both pulls_created and pulls_merged features filter

### DIFF
--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -399,12 +399,18 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 			continue
 		}
 
-		if sub.PullsMerged() && action != actionClosed {
+		if sub.PullsMerged() && action != actionClosed && !sub.PullsCreated() {
 			continue
 		}
 
-		if sub.PullsCreated() && action != actionOpened {
+		if sub.PullsCreated() && action != actionOpened && !sub.PullsMerged() {
 			continue
+		}
+
+		if sub.PullsMerged() && sub.PullsCreated() {
+			if action != actionClosed && action != actionOpened {
+				continue
+			}
 		}
 
 		if p.excludeConfigOrgMember(event.GetSender(), sub) {


### PR DESCRIPTION
#### Summary

There is currently a bug described in the linked issue below. If both `pulls_created` and `pulls_merged` features are set for a subscription, any type of PR events are ignored.

I have fixed the `if` statement, and now it is possible to use both values and receive notifications for the respective event types.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-github/issues/826


