### PR TITLE
[MM-61118] Add diagnostics data to the Support Packet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
-
 )
 
 require (
@@ -81,5 +80,4 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-
 )

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-github/v54 v54.0.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/mattermost/mattermost/server/public v0.1.8
+	github.com/mattermost/mattermost/server/public v0.1.9
 	github.com/microcosm-cc/bluemonday v1.0.19
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v54 v54.0.0
 	github.com/gorilla/mux v1.8.1
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattermost/mattermost/server/public v0.1.7-0.20240815110211-dd2cad30679b
 	github.com/microcosm-cc/bluemonday v1.0.19
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
+
 )
 
 require (
@@ -35,7 +37,6 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,15 @@
 module github.com/mattermost/mattermost-plugin-github
 
-go 1.21
+go 1.22
+
+toolchain go1.22.8
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-github/v54 v54.0.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/mattermost/mattermost/server/public v0.1.7-0.20240815110211-dd2cad30679b
+	github.com/mattermost/mattermost/server/public v0.1.8
 	github.com/microcosm-cc/bluemonday v1.0.19
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.21.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -79,5 +80,5 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+
 )

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956/go.mod h1:SRl30Lb7/QoYyohYeVBuqYvvmXSZJxZgiV3Zf6VbxjI=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
-github.com/mattermost/mattermost/server/public v0.1.8 h1:Z2PUXR4YGquuSo3ojNUl0aazOMSRqALjyMaf20jNIy4=
-github.com/mattermost/mattermost/server/public v0.1.8/go.mod h1:SkTKbMul91Rq0v2dIxe8mqzUOY+3KwlwwLmAlxDfGCk=
+github.com/mattermost/mattermost/server/public v0.1.9 h1:l/OKPRVuFeqL0yqRVC/JpveG5sLNKcT9llxqMkO9e+s=
+github.com/mattermost/mattermost/server/public v0.1.9/go.mod h1:SkTKbMul91Rq0v2dIxe8mqzUOY+3KwlwwLmAlxDfGCk=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956/go.mod h1:SRl30Lb7/QoYyohYeVBuqYvvmXSZJxZgiV3Zf6VbxjI=
 github.com/mattermost/logr/v2 v2.0.21 h1:CMHsP+nrbRlEC4g7BwOk1GAnMtHkniFhlSQPXy52be4=
 github.com/mattermost/logr/v2 v2.0.21/go.mod h1:kZkB/zqKL9e+RY5gB3vGpsyenC+TpuiOenjMkvJJbzc=
-github.com/mattermost/mattermost/server/public v0.1.7-0.20240815110211-dd2cad30679b h1:AkuwRsyzS7UJX9Xp0t8pVOZpmOMwydQ5r9WPZLLs7Aw=
-github.com/mattermost/mattermost/server/public v0.1.7-0.20240815110211-dd2cad30679b/go.mod h1:Dm5uf3z8ckDOKYD1cbnb1Uqm/G9WYIaouSP/HnH+Rbs=
+github.com/mattermost/mattermost/server/public v0.1.8 h1:Z2PUXR4YGquuSo3ojNUl0aazOMSRqALjyMaf20jNIy4=
+github.com/mattermost/mattermost/server/public v0.1.8/go.mod h1:SkTKbMul91Rq0v2dIxe8mqzUOY+3KwlwwLmAlxDfGCk=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/server/plugin/support_packet.go
+++ b/server/plugin/support_packet.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -33,13 +33,13 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 		ConnectedUserCount: connectedUserCount,
 		IsOAuthConfigured:  config.IsOAuthConfigured(),
 	}
-	b, err := yaml.Marshal(diagnostics)
+	body, err := yaml.Marshal(diagnostics)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to marshal diagnostics")
 	}
 
 	return []*model.FileData{{
-		Filename: path.Join(Manifest.Id, "diagnostics.yaml"),
-		Body:     b,
+		Filename: filepath.Join(Manifest.Id, "diagnostics.yaml"),
+		Body:     body,
 	}}, result.ErrorOrNil()
 }

--- a/server/plugin/support_packet.go
+++ b/server/plugin/support_packet.go
@@ -1,0 +1,41 @@
+package plugin
+
+import (
+	"path"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+type SupportPacket struct {
+	Version            string `yaml:"version"`
+	ConnectedUserCount int64  `yaml:"connected_user_count"`
+	IsOAuthConfigured  bool   `yaml:"is_oauth_configured"`
+}
+
+func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, error) {
+	config := p.getConfiguration()
+
+	connectedUserCount, err := p.getConnectedUserCount()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get the number of connected users for Support Packet")
+	}
+
+	diagnostics := SupportPacket{
+		Version:            Manifest.Version,
+		ConnectedUserCount: connectedUserCount,
+		IsOAuthConfigured:  config.IsOAuthConfigured(),
+	}
+	b, err := yaml.Marshal(diagnostics)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to marshal diagnostics")
+	}
+
+	return []*model.FileData{{
+		Filename: path.Join(Manifest.Id, "diagnostics.yaml"),
+		Body:     b,
+	}}, nil
+}

--- a/server/plugin/support_packet.go
+++ b/server/plugin/support_packet.go
@@ -25,7 +25,7 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 
 	connectedUserCount, err := p.getConnectedUserCount()
 	if err != nil {
-		result = multierror.Append(result, errors.Wrap(err, "Failed to get the number of connected users for Support Packet"))
+		result = multierror.Append(result, errors.Wrap(err, "failed to get the number of connected users for Support Packet"))
 	}
 
 	diagnostics := SupportPacket{
@@ -35,7 +35,7 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 	}
 	body, err := yaml.Marshal(diagnostics)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to marshal diagnostics")
+		return nil, errors.Wrap(err, "failed to marshal diagnostics")
 	}
 
 	return []*model.FileData{{

--- a/server/plugin/utils_test.go
+++ b/server/plugin/utils_test.go
@@ -258,11 +258,11 @@ func TestGetToDoDisplayText(t *testing.T) {
 				"",
 				"Discussion",
 				&github.Repository{
-					HTMLURL: model.NewString("https://github.com/mattermost/mattermost-plugin-github"),
+					HTMLURL: model.NewPointer("https://github.com/mattermost/mattermost-plugin-github"),
 					Owner: &github.User{
-						Login: model.NewString("mattermost"),
+						Login: model.NewPointer("mattermost"),
 					},
-					Name: model.NewString("mattermost-plugin-github"),
+					Name: model.NewPointer("mattermost-plugin-github"),
 				},
 			},
 			want: "* [mattermost/...github](https://github.com/mattermost/mattermost-plugin-github) Discussion : Test discussion title!\n",


### PR DESCRIPTION
#### Summary
When a Support Packet gets generated, the plugin now includes diagnostics data via a `diagnostics.yaml` file into the Packet.


Example content of `github/diagnostics.yaml`:

```yaml
version: 2.3.0+6ba0bcd
connected_user_count: 1
is_oauth_configured: true
```

Requires https://github.com/mattermost/mattermost/pull/28833 on the server side.

See https://mattermost.atlassian.net/wiki/spaces/CLOUD/pages/3083108354/Diagnostics+data+from+Core+Plugins+to+the+Support+Packet for more context.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61119

