### PR TITLE
[MM-141]: Made access to KV store atomically safe when saving/removing subscriptions

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -68,6 +68,7 @@ type kvStore interface {
 	ListKeys(page int, count int, options ...pluginapi.ListKeysOption) ([]string, error)
 	Get(key string, o any) error
 	Delete(key string) error
+	SetAtomicWithRetries(key string, valueFunc func(oldValue []byte) (newValue interface{}, err error)) error
 }
 
 type Plugin struct {
@@ -169,7 +170,7 @@ func (p *Plugin) GetGitHubClient(ctx context.Context, userID string) (*github.Cl
 	return p.githubConnectUser(ctx, userInfo), nil
 }
 
-func (p *Plugin) githubConnectUser(ctx context.Context, info *GitHubUserInfo) *github.Client {
+func (p *Plugin) githubConnectUser(_ context.Context, info *GitHubUserInfo) *github.Client {
 	tok := *info.Token
 	return p.githubConnectToken(tok)
 }


### PR DESCRIPTION
#### Summary
Made access to KV store atomically safe when saving/removing subscriptions by using `KV.SetAtomicWithRetries` in place of `KV.Set`

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-github/issues/141

### What to test
- creation of subscription
- working of subscription
- deletion of working of subscription
Note: Keep on eye on the server logs while testing for any type of panic or error arising
