### PR TITLE
[MM-946]: Added testcases for some functions in command.go

### DIFF
--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -1673,7 +1673,7 @@ func TestGetCommand(t *testing.T) {
 	err := os.Mkdir(assetsDir, 0755)
 	require.NoError(t, err)
 	tempFilePath := filepath.Join(assetsDir, "icon-bg.svg")
-	err = os.WriteFile(tempFilePath, []byte("<svg>icon data</svg>"), 0644)
+	err = os.WriteFile(tempFilePath, []byte("<svg>icon data</svg>"), 0600)
 	require.NoError(t, err)
 
 	tests := []struct {


### PR DESCRIPTION
#### Summary
Added test cases for the following functions in command.go
- HandleSubscribe
- HandleSubscriptions
- GetCommand
- HandleHelp
- FormattedString
- ToSlice

#### Parent PR
https://github.com/mattermost/mattermost-plugin-github/pull/845