### PR TITLE
[MM-856]: Added the requested reviewers in the pulls_created notification

### DIFF
--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -215,7 +215,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 
 	template.Must(masterTemplate.New("reviewer").Funcs(funcMap).Parse(`
 {{- if .RequestedReviewers }}
-Requested reviewers: {{range $i, $el := .RequestedReviewers -}} {{- if $i}}, {{end}}{{template "user" $el}}{{end -}}
+Reviewers: {{range $i, $el := .RequestedReviewers -}} {{- if $i}}, {{end}}{{template "user" $el}}{{end -}}
 {{- end -}}
 `))
 

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -213,6 +213,12 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{- end -}}
 `))
 
+	template.Must(masterTemplate.New("reviewer").Funcs(funcMap).Parse(`
+{{- if .RequestedReviewers }}
+Requested reviewers: {{range $i, $el := .RequestedReviewers -}} {{- if $i}}, {{end}}{{template "user" $el}}{{end -}}
+{{- end -}}
+`))
+
 	template.Must(masterTemplate.New("newDraftPR").Funcs(funcMap).Parse(`
 {{template "repo" .Event.GetRepo}} New draft pull request {{template "pullRequest" .Event.GetPullRequest}} was opened by {{template "user" .Event.GetSender}}.
 `))
@@ -227,6 +233,7 @@ Assignees: {{range $i, $el := .Assignees -}} {{- if $i}}, {{end}}{{template "use
 {{- if ne .Config.Style "skip-body" -}}
 {{- template "labels" dict "Labels" .Event.GetPullRequest.Labels "RepositoryURL" .Event.GetRepo.GetHTMLURL  }}
 {{- template "assignee" .Event.GetPullRequest }}
+{{- template "reviewer" .Event.GetPullRequest }}
 
 {{.Event.GetPullRequest.GetBody | removeComments | replaceAllGitHubUsernames}}
 {{- end -}}


### PR DESCRIPTION
#### Summary
Added the requested reviewers in the pulls_created notification

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-github/issues/856
  
#### Screenshots
##### Existing
![Screenshot from 2024-12-03 16-32-17](https://github.com/user-attachments/assets/fb0204cd-1f28-4410-bf9f-67d595f35552)
##### Updated
![Screenshot from 2024-12-03 18-17-18](https://github.com/user-attachments/assets/9e6fb604-9f7b-4d20-8b84-f23fc2331c37)

#### Testing step
- Create a subscription to a project
- Create a PR and add a reviewer to it
- Check the notifcation

