### PR TITLE
[MM-860]: Added message to delete webhook after subscription deletion

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -155,7 +155,7 @@ func (p *Plugin) getMutedUsernames(userInfo *GitHubUserInfo) []string {
 	return mutedUsers
 }
 
-func (p *Plugin) handleMuteList(args *model.CommandArgs, userInfo *GitHubUserInfo) string {
+func (p *Plugin) handleMuteList(_ *model.CommandArgs, userInfo *GitHubUserInfo) string {
 	mutedUsernames := p.getMutedUsernames(userInfo)
 	var mutedUsers string
 	for _, user := range mutedUsernames {
@@ -176,7 +176,7 @@ func contains(s []string, e string) bool {
 	return false
 }
 
-func (p *Plugin) handleMuteAdd(args *model.CommandArgs, username string, userInfo *GitHubUserInfo) string {
+func (p *Plugin) handleMuteAdd(_ *model.CommandArgs, username string, userInfo *GitHubUserInfo) string {
 	mutedUsernames := p.getMutedUsernames(userInfo)
 	if contains(mutedUsernames, username) {
 		return username + " is already muted"
@@ -202,7 +202,7 @@ func (p *Plugin) handleMuteAdd(args *model.CommandArgs, username string, userInf
 	return fmt.Sprintf("`%v`", username) + " is now muted. You'll no longer receive notifications for comments in your PRs and issues."
 }
 
-func (p *Plugin) handleUnmute(args *model.CommandArgs, username string, userInfo *GitHubUserInfo) string {
+func (p *Plugin) handleUnmute(_ *model.CommandArgs, username string, userInfo *GitHubUserInfo) string {
 	mutedUsernames := p.getMutedUsernames(userInfo)
 	userToMute := []string{username}
 	newMutedList := arrayDifference(mutedUsernames, userToMute)
@@ -215,7 +215,7 @@ func (p *Plugin) handleUnmute(args *model.CommandArgs, username string, userInfo
 	return fmt.Sprintf("`%v`", username) + " is no longer muted"
 }
 
-func (p *Plugin) handleUnmuteAll(args *model.CommandArgs, userInfo *GitHubUserInfo) string {
+func (p *Plugin) handleUnmuteAll(_ *model.CommandArgs, userInfo *GitHubUserInfo) string {
 	_, err := p.store.Set(userInfo.UserID+"-muted-users", []byte(""))
 	if err != nil {
 		return "Error occurred unmuting users"
@@ -584,7 +584,8 @@ func (p *Plugin) handleUnsubscribe(_ *plugin.Context, args *model.CommandArgs, p
 	}
 
 	repoLink := baseURL + owner + "/" + repo
-	unsubscribeMessage = fmt.Sprintf("@%v unsubscribed this channel from [%s/%s](%s)", user.Username, owner, repo, repoLink)
+	unsubscribeMessage = fmt.Sprintf("@%v Unsubscribed this channel from [%s/%s](%s)", user.Username, owner, repo, repoLink)
+	unsubscribeMessage += fmt.Sprintf("\n Please delete the [webhook](%s) for this subscription unless it's required for other subscriptions.", fmt.Sprintf("%s/settings/hooks", repoLink))
 
 	if err := p.createPost(args.ChannelId, p.BotUserID, unsubscribeMessage); err != nil {
 		return fmt.Sprintf("%s error creating the public post: %s", unsubscribeMessage, err.Error())


### PR DESCRIPTION
#### Summary
Added message to delete webhook after subscription deletion

#### Screenshots
##### Old
![Screenshot from 2024-12-04 14-23-16](https://github.com/user-attachments/assets/210afe8a-1ae7-489a-a09a-e81de13129dc)
##### New
![Screenshot from 2024-12-04 14-19-54](https://github.com/user-attachments/assets/513e4e86-771d-47e9-949b-3e14b439ccd1)

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-github/issues/860
  
 ##### What to test
- Create subscription
-  Unsubscribe and check the message and test the links 

