### PR TITLE
Fix broken CI on master

### DIFF
--- a/server/plugin/test_utils.go
+++ b/server/plugin/test_utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package plugin
 
 import (


### PR DESCRIPTION
#### Summary
Added missing license header from `server/plugin/test_utils.go`

