### PR TITLE
Fix the "Attach to Github issue" feature to work without organisational lock

### DIFF
--- a/server/plugin/utils.go
+++ b/server/plugin/utils.go
@@ -40,14 +40,16 @@ func getYourAssigneeSearchQuery(username string, orgs []string) string {
 	return buildSearchQuery("is:open assignee:%v archived:false %v", username, orgs)
 }
 
-func getIssuesSearchQuery(org, searchTerm string) string {
+func getIssuesSearchQuery(searchValue, searchTerm string) string {
 	query := "is:open is:issue archived:false %v %v"
-	orgField := ""
-	if len(org) != 0 {
-		orgField = fmt.Sprintf("org:%v", org)
+	searchField := ""
+	if len(searchValue) != 0 {
+		searchField = fmt.Sprintf("org:%v", searchValue)
+	} else { // get all the issues which involve the user in case no organisaitonal lock is set 
+		searchField = fmt.Sprintf("involves:@me")
 	}
 
-	return fmt.Sprintf(query, orgField, searchTerm)
+	return fmt.Sprintf(query, searchField, searchTerm)
 }
 
 func buildSearchQuery(query, username string, orgs []string) string {


### PR DESCRIPTION
#### Summary
Fix the "Attach to Github issue" feature so it works without the organisational lock.
- When the plugin is not set for any organisation then it will fetch all the issues which involve the user 

