### PR TITLE
Fix discussion event notification

### DIFF
--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -490,6 +490,7 @@ Step failed: {{.GetWorkflowJob.Steps | workflowJobFailedStep}}
 {{- if eq .GetAction "created" }} started a new
 {{- else if eq .GetAction "closed" }} closed a
 {{- else if eq .GetAction "reopened" }} reopened a
+{{- else if eq .GetAction "edited" }} edited a
 {{- end }} discussion [#{{.GetDiscussion.GetNumber}} {{.GetDiscussion.GetTitle}}]({{.GetDiscussion.GetHTMLURL}}) on {{template "repo" .GetRepo}}
 `))
 

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -486,7 +486,11 @@ Step failed: {{.GetWorkflowJob.Steps | workflowJobFailedStep}}
 {{- end -}}`))
 
 	template.Must(masterTemplate.New("newDiscussion").Funcs(funcMap).Parse(`
-{{template "user" .GetSender}} started a new discussion [#{{.GetDiscussion.GetNumber}} {{.GetDiscussion.GetTitle}}]({{.GetDiscussion.GetHTMLURL}}) on {{template "repo" .GetRepo}}
+{{template "user" .GetSender}}
+{{- if eq .GetAction "created" }} started a new
+{{- else if eq .GetAction "closed" }} closed a
+{{- else if eq .GetAction "reopened" }} reopened a
+{{- end }} discussion [#{{.GetDiscussion.GetNumber}} {{.GetDiscussion.GetTitle}}]({{.GetDiscussion.GetHTMLURL}}) on {{template "repo" .GetRepo}}
 `))
 
 	template.Must(masterTemplate.New("newDiscussionComment").Funcs(funcMap).Parse(`

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -494,9 +494,13 @@ Step failed: {{.GetWorkflowJob.Steps | workflowJobFailedStep}}
 `))
 
 	template.Must(masterTemplate.New("newDiscussionComment").Funcs(funcMap).Parse(`
-{{template "repo" .GetRepo}} New comment by {{template "user" .GetSender}} on discussion [#{{.GetDiscussion.GetNumber}} {{.GetDiscussion.GetTitle}}]({{.GetDiscussion.GetHTMLURL}}):
+{{template "repo" .GetRepo}} 
+{{- if eq .GetAction "created" }} New comment 
+{{- else if eq .GetAction "edited" }} Comment edited
+{{- else if eq .GetAction "deleted" }} Comment deleted
+{{- end }} by {{template "user" .GetSender}} on discussion [#{{.GetDiscussion.GetNumber}} {{.GetDiscussion.GetTitle}}]({{.GetDiscussion.GetHTMLURL}}):
 
-{{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
+> {{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
 `))
 }
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -1508,10 +1508,6 @@ func (p *Plugin) postDiscussionCommentEvent(event *github.DiscussionCommentEvent
 		return
 	}
 
-	if event.GetAction() != actionCreated {
-		return
-	}
-
 	newDiscussionCommentMessage, err := renderTemplate("newDiscussionComment", event)
 	if err != nil {
 		p.client.Log.Warn("Failed to render template", "error", err.Error())


### PR DESCRIPTION
#### Summary
The discussion events were getting the same msg for "created", "closed" and "reopened" events and similarly for comment events. We updated it to include a custom message for each event.

#### Screenshots
BEFORE:
![image](https://github.com/user-attachments/assets/75462c38-0a80-4beb-ba7f-72f446a5e4c0)

AFTER:
![image](https://github.com/user-attachments/assets/a33d5c26-1f7a-4136-9719-5ee386803375)
![image](https://github.com/user-attachments/assets/22ed59e8-e990-4c84-8bdf-ffb2449d8906)


