### PR TITLE
MM-68363: redact post contents from error logs to prevent sensitive data exposure

### DIFF
--- a/server/plugin/command.go
+++ b/server/plugin/command.go
@@ -401,7 +401,7 @@ func (p *Plugin) createPost(channelID, userID, message string) error {
 	}
 
 	if err := p.client.Post.CreatePost(post); err != nil {
-		p.client.Log.Warn("Error while creating post", "post", post, "error", err.Error())
+		p.client.Log.Warn("Error while creating post", "channel_id", post.ChannelId, "error", err.Error())
 		return err
 	}
 

--- a/server/plugin/command_test.go
+++ b/server/plugin/command_test.go
@@ -1063,7 +1063,7 @@ func TestCreatePost(t *testing.T) {
 			name: "Error creating a post",
 			setup: func() {
 				mockAPI.On("CreatePost", post).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error while creating post", "post", post, "error", "error creating post").Times(1)
+				mockAPI.On("LogWarn", "Error while creating post", "channel_id", mock.Anything, "error", "error creating post").Times(1)
 			},
 			assertions: func(t *testing.T, err error) {
 				assert.EqualError(t, err, "error creating post")
@@ -1179,7 +1179,7 @@ func TestHandleUnsubscribe(t *testing.T) {
 				mockAPI.On("GetUser", MockUserID).Return(&model.User{Username: MockUsername}, nil).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
 				post.Message = "@mockUsername unsubscribed this channel from [owner](https://github.com/owner)"
-				mockAPI.On("LogWarn", "Error while creating post", "post", post, "error", "error creating post").Times(1)
+				mockAPI.On("LogWarn", "Error while creating post", "channel_id", mock.Anything, "error", "error creating post").Times(1)
 				mockKVStore.EXPECT().SetAtomicWithRetries(SubscriptionsKey, gomock.Any()).Return(nil).Times(1)
 			},
 			assertions: func(result string) {
@@ -1217,7 +1217,7 @@ func TestHandleUnsubscribe(t *testing.T) {
 				mockAPI.On("GetUser", MockUserID).Return(&model.User{Username: MockUsername}, nil).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
 				post.Message = "@mockUsername Unsubscribed this channel from [owner/repo](https://github.com/owner/repo)\n Please delete the [webhook](https://github.com/owner/repo/settings/hooks) for this subscription unless it's required for other subscriptions."
-				mockAPI.On("LogWarn", "Error while creating post", "post", post, "error", "error creating post").Times(1)
+				mockAPI.On("LogWarn", "Error while creating post", "channel_id", mock.Anything, "error", "error creating post").Times(1)
 				mockKVStore.EXPECT().SetAtomicWithRetries(SubscriptionsKey, gomock.Any()).Return(nil).Times(1)
 			},
 			assertions: func(result string) {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -962,7 +962,7 @@ func (p *Plugin) CreateBotDMPost(userID, message, postType string) {
 	}
 
 	if err = p.client.Post.CreatePost(post); err != nil {
-		p.client.Log.Warn("Failed to create DM post", "userID", userID, "post", post, "error", err.Error())
+		p.client.Log.Warn("Failed to create DM post", "user_id", userID, "channel_id", post.ChannelId, "error", err.Error())
 		return
 	}
 }

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -561,7 +561,7 @@ func (p *Plugin) postPullRequestEvent(event *github.PullRequestEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if err := p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -624,7 +624,7 @@ func (p *Plugin) handlePRDescriptionMentionNotification(event *github.PullReques
 		post.ChannelId = channel.Id
 
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 
 		p.sendRefreshEvent(userID)
@@ -725,7 +725,7 @@ func (p *Plugin) postIssueEvent(event *github.IssuesEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -768,7 +768,7 @@ func (p *Plugin) postPushEvent(event *github.PushEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -809,7 +809,7 @@ func (p *Plugin) postCreateEvent(event *github.CreateEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -851,7 +851,7 @@ func (p *Plugin) postDeleteEvent(event *github.DeleteEvent) {
 		post := p.makeBotPost(newDeleteMessage, "custom_git_delete")
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -922,7 +922,7 @@ func (p *Plugin) postIssueCommentEvent(event *github.IssueCommentEvent) {
 		post.ChannelId = sub.ChannelID
 
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1011,7 +1011,7 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1072,7 +1072,7 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1470,7 +1470,7 @@ func (p *Plugin) postStarEvent(event *github.StarEvent) {
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "post", post, "error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1510,7 +1510,7 @@ func (p *Plugin) postWorkflowJobEvent(event *github.WorkflowJobEvent) {
 		}
 
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "Post", post, "Error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1563,7 +1563,7 @@ func (p *Plugin) postWorkflowRunEvent(event *github.WorkflowRunEvent) {
 		}
 
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "Post", post, "Error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1607,7 +1607,7 @@ func (p *Plugin) postReleaseEvent(event *github.ReleaseEvent) {
 		}
 
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error webhook post", "Post", post, "Error", err.Error())
+			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1645,7 +1645,7 @@ func (p *Plugin) postDiscussionEvent(event *github.DiscussionEvent) {
 		post.AddProp(postPropGithubObjectType, "discussion")
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error creating discussion notification post", "Post", post, "Error", err.Error())
+			p.client.Log.Warn("Error creating discussion notification post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }
@@ -1683,7 +1683,7 @@ func (p *Plugin) postDiscussionCommentEvent(event *github.DiscussionCommentEvent
 
 		post.ChannelId = sub.ChannelID
 		if err = p.client.Post.CreatePost(post); err != nil {
-			p.client.Log.Warn("Error creating discussion comment post", "Post", post, "Error", err.Error())
+			p.client.Log.Warn("Error creating discussion comment post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
 }

--- a/server/plugin/webhook_test.go
+++ b/server/plugin/webhook_test.go
@@ -105,7 +105,7 @@ func TestPostPushEvent(t *testing.T) {
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post")
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -161,7 +161,7 @@ func TestPostCreateEvent(t *testing.T) {
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post")
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -217,7 +217,7 @@ func TestPostDeleteEvent(t *testing.T) {
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post")
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -282,7 +282,7 @@ func TestPostIssueCommentEvent(t *testing.T) {
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post").Times(1)
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post").Times(1)
 			},
 		},
 		{
@@ -450,7 +450,7 @@ func TestPostPullRequestReviewEvent(t *testing.T) {
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post").Times(1)
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post").Times(1)
 			},
 		},
 		{
@@ -499,7 +499,7 @@ func TestPostPullRequestReviewCommentEvent(t *testing.T) {
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post").Times(1)
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post").Times(1)
 			},
 		},
 		{
@@ -1305,7 +1305,7 @@ func TestPostStarEvent(t *testing.T) {
 					},
 				})).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "post", mock.Anything, "error", "error creating post")
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -1375,7 +1375,7 @@ func TestPostReleaseEvent(t *testing.T) {
 					},
 				})).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "Post", mock.Anything, "Error", "error creating post")
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -1440,7 +1440,7 @@ func TestPostDiscussionEvent(t *testing.T) {
 					},
 				})).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error creating discussion notification post", "Post", mock.Anything, "Error", "error creating post")
+				mockAPI.On("LogWarn", "Error creating discussion notification post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -1593,7 +1593,7 @@ func TestPostWorkflowRunEvent(t *testing.T) {
 					},
 				})).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error webhook post", "Post", mock.Anything, "Error", "error creating post")
+				mockAPI.On("LogWarn", "Error webhook post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{
@@ -1702,7 +1702,7 @@ func TestPostDiscussionCommentEvent(t *testing.T) {
 					},
 				})).Times(1)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
-				mockAPI.On("LogWarn", "Error creating discussion comment post", "Post", mock.Anything, "Error", "error creating post")
+				mockAPI.On("LogWarn", "Error creating discussion comment post", "channel_id", mock.Anything, "error", "error creating post")
 			},
 		},
 		{


### PR DESCRIPTION

#### Summary
Replace all instances of logging the full model.Post struct in error log statements with only non-sensitive metadata. Previously, when a post creation failed, the entire post was logged which could expose sensitive or private user content in Grafana.

#### QA Test Steps
Set up a GitHub plugin instance connected to a test repository with channel subscriptions.
Trigger a webhook event that would create a post.
Cause the notification to fail for example, by making the message too long so the server rejects it.
Check the server logs (Grafana or local logs) for the resulting warn-level log entry. ( can help with that )
Verify the log entry contains channel_id and error fields but does not contain a post field with message content.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68363
