### PR TITLE
Added handling for cases where the user in a PR review is missing

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -859,7 +859,15 @@ func fetchReviews(c *UserContext, client *github.Client, repoOwner string, repoN
 		return []*github.PullRequestReview{}, errors.Wrap(err, "could not list reviews")
 	}
 
-	return reviewsList, nil
+	// Filtering reviews where user is nil
+	filtered := make([]*github.PullRequestReview, 0, len(reviewsList))
+	for _, review := range reviewsList {
+		if review != nil && review.User != nil {
+			filtered = append(filtered, review)
+		}
+	}
+
+	return filtered, nil
 }
 
 func getRepoOwnerAndNameFromURL(rawURL string) (string, string, error) {

--- a/webapp/src/components/sidebar_right/github_items.tsx
+++ b/webapp/src/components/sidebar_right/github_items.tsx
@@ -407,7 +407,11 @@ function getReviewText(item: GithubItem, style: any, secondLine: boolean) {
     };
 
     const lastReviews = item.reviews.reduce(reverse, []).filter((v) => {
-        if (v.user.login === item.user.login) {
+        if (!v.user) {
+            return false;
+        }
+
+        if (item.user && v.user.login === item.user.login) {
             return false;
         }
 

--- a/webapp/src/types/github_types.ts
+++ b/webapp/src/types/github_types.ts
@@ -17,7 +17,7 @@ type GitHubUser = {
 
 export type Review = {
     state: string;
-    user: GitHubUser;
+    user?: GitHubUser;
 }
 
 export type GithubItem = PrsDetailsData & {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
There is an edge case where if an account that previously reviewed the PR is deleted, the list of PRs in the sidebar will fail to load as it attempts to read the user attribute for the review.

This PR combats this by both filtering the PR reviews that don't have an user attached to them, as well as adding some defensive coding on the webapp to also prevent this from affecting the rendering of the sidebar contents

| Before | After |
| :--: | :--: |
| <img width="462" height="466" alt="image" src="https://github.com/user-attachments/assets/c8ef5d59-be8d-4273-b14a-3bf6d47326ba" /> | <img width="453" height="501" alt="image" src="https://github.com/user-attachments/assets/2fc79e41-6583-4ab0-9526-d571886a45dd" /> |

#### QA Notes
Reproducing this naturally is somewhat difficult given that you need to have given a review to a PR with a temporary account that is then deleted. The easiest way to confirm that the fix is working would be to use a browser extension to mock the response of `/plugins/github/api/v1/prsdetails` and remove the `user` object from one of the reviews.

Once that is done just connect your account and open the "Your Open Pull Requests" sidebar from the LHS menu buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** These changes span both backend and frontend to handle the edge case of missing review authors, and include a type definition change to optionality. While the changes are isolated to review handling and are purely defensive, the scope across layers and the modification to the data model warrant medium-level scrutiny.

**Regression Risk:** Low. The changes add null-checking guards before accessing potentially undefined properties and filter invalid reviews server-side before transmission. No existing behavioral logic is modified; these are additive defensive measures that prevent crashes in an edge case (deleted/missing user accounts in PR reviews) without altering normal operation.

**QA Recommendation:** Light manual QA is recommended. Primary verification: confirm the "Your Open Pull Requests" sidebar loads successfully when a PR contains a review from a deleted/missing user account. The PR provides browser dev tools instructions to mock the edge case. Risk of skipping QA is medium—while changes are defensive and low-regression, the sidebar is user-facing and the edge case being fixed is real. A quick smoke test of sidebar loading with typical PRs is sufficient for low-risk release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->