### PR TITLE
MM-68540: Stop pushing sidebar data over cluster WS; refetch via REST

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -5,7 +5,6 @@ package plugin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,7 +24,6 @@ import (
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
-	"github.com/mattermost/mattermost/server/public/pluginapi/experimental/bot/logger"
 	"github.com/mattermost/mattermost/server/public/pluginapi/experimental/bot/poster"
 
 	"github.com/mattermost/mattermost-plugin-github/server/plugin/graphql"
@@ -1305,64 +1303,18 @@ func (p *Plugin) isOrganizationLocked() bool {
 }
 
 func (p *Plugin) sendRefreshEvent(userID string) {
-	eventLogger := logger.New(p.API).With(logger.LogContext{
-		"userid": userID,
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-
-	context := &Context{
-		Ctx:    ctx,
-		UserID: userID,
-		Log:    eventLogger,
-	}
-
-	defer cancel()
-
-	info, apiErr := p.getGitHubUserInfo(context.UserID)
-	if apiErr != nil {
+	if _, apiErr := p.getGitHubUserInfo(userID); apiErr != nil {
 		if apiErr.ID != apiErrorIDNotConnected {
 			p.client.Log.Debug("Failed to get github user info", "error", apiErr.Error())
 		}
 		return
 	}
 
-	userContext := &UserContext{
-		Context: *context,
-		GHInfo:  info,
-	}
-
-	sidebarContent, err := p.getSidebarData(userContext)
-	if err != nil {
-		p.client.Log.Warn("Failed to get the sidebar data", "error", err.Error())
-		return
-	}
-
-	contentMap, err := sidebarContent.toMap()
-	if err != nil {
-		p.client.Log.Warn("Failed to convert sidebar content to map", "error", err.Error())
-		return
-	}
-
 	p.client.Frontend.PublishWebSocketEvent(
 		wsEventRefresh,
-		contentMap,
+		map[string]any{"user_id": userID},
 		&model.WebsocketBroadcast{UserId: userID},
 	)
-}
-
-func (s *SidebarContent) toMap() (map[string]any, error) {
-	var m map[string]any
-	bytes, err := json.Marshal(&s)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = json.Unmarshal(bytes, &m); err != nil {
-		return nil, err
-	}
-
-	return m, nil
 }
 
 // getUsername returns the GitHub username for a given Mattermost user,

--- a/webapp/src/websocket/index.js
+++ b/webapp/src/websocket/index.js
@@ -79,14 +79,9 @@ export function handleReconnect(store, reminder = false) {
 }
 
 export function handleRefresh(store) {
-    return (msg) => {
+    return () => {
         if (store.getState()[`plugins-${manifest.id}`].connected) {
-            const {data} = msg;
-
-            store.dispatch({
-                type: ActionTypes.RECEIVED_SIDEBAR_CONTENT,
-                data,
-            });
+            getSidebarContent()(store.dispatch, store.getState);
         }
     };
 }


### PR DESCRIPTION
#### Summary
This change makes sendRefreshEvent ship just {user_id}, and the webapp's handleRefresh dispatches the existing refetch action instead of consuming the embedded payload.
Net wire payload drops from ~250 KB to ~50 bytes.


Verified on test server https://github-test.test.mattermost.cloud/test-github/ that the new payload is minimal:

```
{
    "event": "custom_github_refresh",
    "data": {
        "user_id": "h47wpohqsbdwxrxnydxf6t8t8e"
    },
    "broadcast": {
        "omit_users": null,
        "user_id": "h47wpohqsbdwxrxnydxf6t8t8e",
        "channel_id": "",
        "team_id": "",
        "connection_id": "",
        "omit_connection_id": ""
    },
    "seq": 8
}
``` 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The PR modifies a critical user-facing sidebar refresh mechanism that is triggered by multiple webhook events across the system. While the changes successfully reduce wire payload from ~250KB to ~50 bytes, the conversion from synchronous embedded-data delivery to asynchronous REST-based fetching introduces a new failure mode where REST timeouts or errors could silently leave sidebar content stale—a regression from the previous guaranteed-delivery semantics.

**Regression Risk:** The handler parameter change from `(msg) => {}` to `() => {}` is safe in isolation, but the underlying shift from receiving data over WebSocket to fetching it via REST removes built-in resilience. If `getSidebarContent()` REST calls fail, encounter timeouts, or experience rate-limiting, users will see no sidebar updates—whereas the old embedded-payload approach guaranteed delivery within the WebSocket frame. The `connected` state check provides some mitigation but doesn't handle REST-specific failures. The function is called frequently from 6+ webhook event handlers, so any issues will affect multiple user workflows.

**QA Recommendation:** Moderate-to-full manual QA is recommended. Test scenarios should include: sidebar refresh under poor network conditions, REST endpoint slowness/timeouts, server errors during REST calls, rapid consecutive refresh triggers (webhook storms), and recovery after transient failures. Verify sidebar doesn't appear frozen or stale if REST calls fail. All webhook event types that trigger `sendRefreshEvent` should be manually tested. The localized nature of the change allows for targeted testing rather than full regression, but the importance of the sidebar feature warrants comprehensive QA coverage. Adding unit tests for error paths in `handleRefresh` and `sendRefreshEvent` would significantly reduce ongoing risk.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->