### PR TITLE
MM-68364: Truncate oversized GitHub plugin DM posts to avoid silent drops

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-github/v54/github"
 	"github.com/gorilla/mux"
@@ -957,7 +958,7 @@ func (p *Plugin) CreateBotDMPost(userID, message, postType string) {
 	post := &model.Post{
 		UserId:    p.BotUserID,
 		ChannelId: channel.Id,
-		Message:   message,
+		Message:   truncatePostMessage(message),
 		Type:      postType,
 	}
 
@@ -965,6 +966,21 @@ func (p *Plugin) CreateBotDMPost(userID, message, postType string) {
 		p.client.Log.Warn("Failed to create DM post", "user_id", userID, "channel_id", post.ChannelId, "error", err.Error())
 		return
 	}
+}
+
+func truncatePostMessage(message string) string {
+	const truncationMarker = "\n\n_… message truncated_"
+
+	if utf8.RuneCountInString(message) <= model.PostMessageMaxRunesV2 {
+		return message
+	}
+
+	keep := model.PostMessageMaxRunesV2 - utf8.RuneCountInString(truncationMarker)
+	if keep <= 0 {
+		return string([]rune(truncationMarker)[:model.PostMessageMaxRunesV2])
+	}
+
+	return string([]rune(message)[:keep]) + truncationMarker
 }
 
 func (p *Plugin) CheckIfDuplicateDailySummary(userID, text string) (bool, error) {

--- a/server/plugin/plugin_test.go
+++ b/server/plugin/plugin_test.go
@@ -5,7 +5,9 @@ package plugin
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -373,4 +375,34 @@ func TestForceDisconnectUser_DeleteErrors(t *testing.T) {
 	p.forceDisconnectUser("user1", "ghuser1")
 
 	api.AssertExpectations(t)
+}
+
+func TestTruncatePostMessage(t *testing.T) {
+	t.Run("short message is returned unchanged", func(t *testing.T) {
+		msg := "hello world"
+		require.Equal(t, msg, truncatePostMessage(msg))
+	})
+
+	t.Run("message at the rune limit is returned unchanged", func(t *testing.T) {
+		msg := strings.Repeat("a", model.PostMessageMaxRunesV2)
+		require.Equal(t, msg, truncatePostMessage(msg))
+	})
+
+	t.Run("oversized ASCII message is truncated and marker appended", func(t *testing.T) {
+		msg := strings.Repeat("a", model.PostMessageMaxRunesV2+5_000)
+		out := truncatePostMessage(msg)
+
+		require.LessOrEqual(t, utf8.RuneCountInString(out), model.PostMessageMaxRunesV2)
+		require.True(t, strings.HasSuffix(out, "_… message truncated_"))
+	})
+
+	t.Run("oversized multibyte message keeps rune boundaries", func(t *testing.T) {
+		// Each rune is 3 bytes, so byte-based truncation would corrupt the output.
+		msg := strings.Repeat("✓", model.PostMessageMaxRunesV2+1_000)
+		out := truncatePostMessage(msg)
+
+		require.LessOrEqual(t, utf8.RuneCountInString(out), model.PostMessageMaxRunesV2)
+		require.True(t, utf8.ValidString(out), "truncated output should remain valid UTF-8")
+		require.True(t, strings.HasSuffix(out, "_… message truncated_"))
+	})
 }


### PR DESCRIPTION
#### Summary
This PR truncates the message body in the central `CreateBotDMPost` helper before sending. The cap uses `model.PostMessageMaxRunesV2` to preserve UTF-8 boundaries and truncated messages get a `_… message truncated_` marker so users know to check GitHub for the full content.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The change introduces truncation logic to a widely-used central utility function (`CreateBotDMPost`) that handles GitHub webhook notifications and event-triggered DM messages. While the modification is backward-compatible and well-tested, its broad usage across notification flows and potential impact on user-facing messaging necessitates medium-level scrutiny.

**Regression Risk:** Low-to-Medium. The truncation logic only activates when messages exceed `model.PostMessageMaxRunesV2`; shorter messages pass through unchanged. The function signature remains identical, so callers are unaffected. However, the change affects every DM post created by the plugin (webhook notifications, account management notifications, API responses), and incorrect truncation or UTF-8 boundary violations could silently alter message content. The new test coverage for `truncatePostMessage` mitigates this with explicit tests for multibyte characters and rune boundary preservation.

**QA Recommendation:** Manual testing should verify that: (1) oversized GitHub webhook messages (e.g., long issue descriptions, PR review comments) are properly truncated with the marker and remain readable, (2) multibyte UTF-8 characters (emojis, non-Latin scripts) are not corrupted during truncation, and (3) normal-sized messages are unaffected. Automated test coverage is good; manual QA can be brief and focused on message boundary cases. Rollback risk is low due to backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->