### PR TITLE
MM-68540: Drop redundant user_id from refresh WS payload

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -1312,7 +1312,7 @@ func (p *Plugin) sendRefreshEvent(userID string) {
 
 	p.client.Frontend.PublishWebSocketEvent(
 		wsEventRefresh,
-		map[string]any{"user_id": userID},
+		nil,
 		&model.WebsocketBroadcast{UserId: userID},
 	)
 }


### PR DESCRIPTION

#### Summary
Followup to #1002. The WS event is purely a doorbell now and the recipient is already targeted by WebsocketBroadcast.UserId and the webapp handler doesn't read msg.data. Sending user_id was both unused
and unnecessary.


