### PR TITLE
MM-68375: Verify channel membership before posting from createissue nd createissuecomment handlers

### DIFF
--- a/server/plugin/api.go
+++ b/server/plugin/api.go
@@ -1027,6 +1027,11 @@ func (p *Plugin) createIssueComment(c *UserContext, w http.ResponseWriter, r *ht
 		return
 	}
 
+	if !p.client.User.HasPermissionToChannel(c.UserID, post.ChannelId, model.PermissionCreatePost) {
+		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "not authorized to post in this channel", StatusCode: http.StatusForbidden})
+		return
+	}
+
 	commentUsername, err := p.getUsername(post.UserId)
 	if err != nil {
 		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "failed to get username", StatusCode: http.StatusInternalServerError})
@@ -1726,6 +1731,11 @@ func (p *Plugin) createIssue(c *UserContext, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if issue.PostID == "" && !p.client.User.HasPermissionToChannel(c.UserID, issue.ChannelID, model.PermissionCreatePost) {
+		p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "not authorized to post in this channel", StatusCode: http.StatusForbidden})
+		return
+	}
+
 	mmMessage := ""
 	var post *model.Post
 	permalink := ""
@@ -1738,6 +1748,11 @@ func (p *Plugin) createIssue(c *UserContext, w http.ResponseWriter, r *http.Requ
 		}
 		if post == nil {
 			p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "failed to load post " + issue.PostID + ": not found", StatusCode: http.StatusNotFound})
+			return
+		}
+
+		if !p.client.User.HasPermissionToChannel(c.UserID, post.ChannelId, model.PermissionCreatePost) {
+			p.writeAPIError(w, &APIErrorResponse{ID: "", Message: "not authorized to post in this channel", StatusCode: http.StatusForbidden})
 			return
 		}
 


### PR DESCRIPTION

#### Summary
Add channel membership verification to createissue and createissuecomment handlers before creating replies in the associated channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68375


#### QA with Curl 
Create two users:
User A is member of a private channel
User B is not a member

Connect User B via /github connect. User B needs at least one repo they can create issues on.
As User A post any message in private-test. Right-click → Copy ID.
Get User B's session token: in their browser DevTools → Application → Cookies → MMAUTHTOKEN.

Verified: 
1. createissuecomment now return 403
```
curl -i -X POST https://<your-mm-url>/plugins/github/api/v1/createissuecomment \
  -H "Cookie: MMAUTHTOKEN=<USER_B_TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{
    "post_id": "<POST_ID>",
    "owner": "<USER_B_GITHUB_OWNER>",
    "repo": "<USER_B_TEST_REPO>",
    "number": 1,
    "comment": "qa test"
  }'
  
  Body: {"id":"","message":"not authorized to post in this channel","status_code":403}

  ```
Same for createissue with post_id.
