### PR TITLE
MM-68829 Improving UX for DMs sent on PR comments

### DIFF
--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -75,9 +75,6 @@ func init() {
 		}
 		cleaned = mdCommentRegex.ReplaceAllString(cleaned, "")
 		cleaned = strings.TrimSpace(cleaned)
-		if cleaned == "" {
-			return ""
-		}
 		return cleaned
 	}
 

--- a/server/plugin/template.go
+++ b/server/plugin/template.go
@@ -68,6 +68,19 @@ func init() {
 		return mdCommentRegex.ReplaceAllString(body, "")
 	}
 
+	funcMap["cleanBody"] = func(body string) string {
+		cleaned := body
+		if strings.Contains(cleaned, "notifications@github.com") {
+			cleaned = strings.Split(cleaned, "\n\nOn")[0]
+		}
+		cleaned = mdCommentRegex.ReplaceAllString(cleaned, "")
+		cleaned = strings.TrimSpace(cleaned)
+		if cleaned == "" {
+			return ""
+		}
+		return cleaned
+	}
+
 	// Replace any GitHub username with its corresponding Mattermost username, if any
 	funcMap["replaceAllGitHubUsernames"] = func(body string) string {
 		return gitHubUsernameRegex.ReplaceAllStringFunc(body, func(matched string) string {
@@ -360,39 +373,76 @@ Reviewers: {{range $i, $el := .RequestedReviewers -}} {{- if $i}}, {{end}}{{temp
 {{.GetComment.GetBody | trimBody | replaceAllGitHubUsernames}}
 `))
 
+	template.Must(masterTemplate.New("reviewCommentMentionNotification").Funcs(funcMap).Parse(`
+{{template "user" .GetSender}} mentioned you in a review comment on [{{.GetRepo.GetFullName}}#{{.GetPullRequest.GetNumber}}]({{.GetComment.GetHTMLURL}}) - {{.GetPullRequest.GetTitle}}:
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
+`))
+
+	template.Must(masterTemplate.New("reviewCommentAuthorNotification").Funcs(funcMap).Parse(`
+{{template "user" .GetSender}} commented on your pull request [{{.GetRepo.GetFullName}}#{{.GetPullRequest.GetNumber}}]({{.GetComment.GetHTMLURL}}) - {{.GetPullRequest.GetTitle}}:
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
+`))
+
 	template.Must(masterTemplate.New("commentMentionNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} mentioned you on [{{.GetRepo.GetFullName}}#{{.Issue.GetNumber}}]({{.GetComment.GetHTMLURL}}) - {{.Issue.GetTitle}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("commentAuthorPullRequestNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} commented on your pull request {{template "eventRepoIssueFullLinkWithTitle" .}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("commentAssigneePullRequestNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} commented on pull request you are assigned to {{template "eventRepoIssueFullLinkWithTitle" .}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("commentAssigneeIssueNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} commented on an issue you are assigned to {{template "eventRepoIssueFullLinkWithTitle" .}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("commentAssigneeSelfMentionPullRequestNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} mentioned you on a pull request that you are assigned to {{template "eventRepoIssueFullLinkWithTitle" .}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("commentAssigneeSelfMentionIssueNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} mentioned you on an issue that you are assigned to {{template "eventRepoIssueFullLinkWithTitle" .}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("commentAuthorIssueNotification").Funcs(funcMap).Parse(`
 {{template "user" .GetSender}} commented on your issue {{template "eventRepoIssueFullLinkWithTitle" .}}:
-{{.GetComment.GetBody | trimBody | quote | replaceAllGitHubUsernames}}
+{{- $body := .GetComment.GetBody | cleanBody | replaceAllGitHubUsernames}}
+{{- if $body}}
+{{$body | quote}}
+{{- end}}
 `))
 
 	template.Must(masterTemplate.New("pullRequestNotification").Funcs(funcMap).Parse(`

--- a/server/plugin/test_utils.go
+++ b/server/plugin/test_utils.go
@@ -280,8 +280,9 @@ func GetMockPullRequestReviewEvent(action, state, repo string, isPrivate bool, r
 	}
 }
 
-func GetMockPullRequestReviewCommentEvent() *github.PullRequestReviewCommentEvent {
+func GetMockPullRequestReviewCommentEvent(action, body, sender string) *github.PullRequestReviewCommentEvent {
 	return &github.PullRequestReviewCommentEvent{
+		Action: github.String(action),
 		Repo: &github.Repository{
 			Name:     github.String(MockRepoName),
 			FullName: github.String(MockOrgRepo),
@@ -290,13 +291,15 @@ func GetMockPullRequestReviewCommentEvent() *github.PullRequestReviewCommentEven
 		},
 		Comment: &github.PullRequestComment{
 			ID:      github.Int64(12345),
-			Body:    github.String("This is a review comment"),
+			Body:    github.String(body),
 			HTMLURL: github.String(fmt.Sprintf("%s%s/pull/1#discussion_r12345", GithubBaseURL, MockOrgRepo)),
 		},
 		Sender: &github.User{
-			Login: github.String(MockUserLogin),
+			Login: github.String(sender),
 		},
-		PullRequest: &github.PullRequest{},
+		PullRequest: &github.PullRequest{
+			User: &github.User{Login: github.String(MockIssueAuthor)},
+		},
 	}
 }
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -1094,6 +1094,8 @@ func (p *Plugin) handleReviewCommentMentionNotification(event *github.PullReques
 		body = strings.Split(body, "\n\nOn")[0]
 	}
 
+	body = mdCommentRegex.ReplaceAllString(body, "")
+
 	mentionedUsernames := parseGitHubUsernamesFromText(body)
 
 	message, err := renderTemplate("reviewCommentMentionNotification", event)
@@ -1103,11 +1105,11 @@ func (p *Plugin) handleReviewCommentMentionNotification(event *github.PullReques
 	}
 
 	for _, username := range mentionedUsernames {
-		if username == event.GetSender().GetLogin() {
+		if strings.EqualFold(username, event.GetSender().GetLogin()) {
 			continue
 		}
 
-		if username == event.GetPullRequest().GetUser().GetLogin() {
+		if strings.EqualFold(username, event.GetPullRequest().GetUser().GetLogin()) {
 			continue
 		}
 
@@ -1141,7 +1143,7 @@ func (p *Plugin) handleReviewCommentMentionNotification(event *github.PullReques
 
 func (p *Plugin) handleReviewCommentAuthorNotification(event *github.PullRequestReviewCommentEvent) {
 	author := event.GetPullRequest().GetUser().GetLogin()
-	if author == event.GetSender().GetLogin() {
+	if strings.EqualFold(author, event.GetSender().GetLogin()) {
 		return
 	}
 

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -287,6 +287,8 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		repo = event.GetRepo()
 		handler = func() {
 			p.postPullRequestReviewCommentEvent(event)
+			p.handleReviewCommentMentionNotification(event)
+			p.handleReviewCommentAuthorNotification(event)
 		}
 	case *github.PushEvent:
 		repo = ConvertPushEventRepositoryToRepository(event.GetRepo())
@@ -1019,12 +1021,16 @@ func (p *Plugin) postPullRequestReviewEvent(event *github.PullRequestReviewEvent
 func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestReviewCommentEvent) {
 	repo := event.GetRepo()
 
+	if event.GetAction() != actionCreated {
+		return
+	}
+
 	subs := p.GetSubscribedChannelsForRepository(repo)
 	if len(subs) == 0 {
 		return
 	}
 
-	newReviewMessage, err := renderTemplate("newReviewComment", event)
+	message, err := renderTemplate("newReviewComment", event)
 	if err != nil {
 		p.client.Log.Warn("Failed to render template", "error", err.Error())
 		return
@@ -1061,7 +1067,7 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 			continue
 		}
 
-		post := p.makeBotPost(newReviewMessage, "custom_git_pr_comment")
+		post := p.makeBotPost(message, "custom_git_pr_comment")
 
 		repoName := strings.ToLower(repo.GetFullName())
 		commentID := event.GetComment().GetID()
@@ -1075,6 +1081,95 @@ func (p *Plugin) postPullRequestReviewCommentEvent(event *github.PullRequestRevi
 			p.client.Log.Warn("Error webhook post", "channel_id", post.ChannelId, "error", err.Error())
 		}
 	}
+}
+
+func (p *Plugin) handleReviewCommentMentionNotification(event *github.PullRequestReviewCommentEvent) {
+	if event.GetAction() != actionCreated {
+		return
+	}
+
+	body := event.GetComment().GetBody()
+
+	if strings.Contains(body, "notifications@github.com") {
+		body = strings.Split(body, "\n\nOn")[0]
+	}
+
+	mentionedUsernames := parseGitHubUsernamesFromText(body)
+
+	message, err := renderTemplate("reviewCommentMentionNotification", event)
+	if err != nil {
+		p.client.Log.Warn("Failed to render template", "error", err.Error())
+		return
+	}
+
+	for _, username := range mentionedUsernames {
+		if username == event.GetSender().GetLogin() {
+			continue
+		}
+
+		if username == event.GetPullRequest().GetUser().GetLogin() {
+			continue
+		}
+
+		userID := p.getGitHubToUserIDMapping(username)
+		if userID == "" {
+			continue
+		}
+
+		if event.GetRepo().GetPrivate() && !p.permissionToRepo(userID, event.GetRepo().GetFullName()) {
+			continue
+		}
+
+		if p.senderMutedByReceiver(userID, event.GetSender().GetLogin()) {
+			continue
+		}
+
+		channel, err := p.client.Channel.GetDirect(userID, p.BotUserID)
+		if err != nil {
+			continue
+		}
+
+		post := p.makeBotPost(message, "custom_git_mention")
+		post.ChannelId = channel.Id
+		if err = p.client.Post.CreatePost(post); err != nil {
+			p.client.Log.Warn("Error creating review comment mention post", "error", err.Error())
+		}
+
+		p.sendRefreshEvent(userID)
+	}
+}
+
+func (p *Plugin) handleReviewCommentAuthorNotification(event *github.PullRequestReviewCommentEvent) {
+	author := event.GetPullRequest().GetUser().GetLogin()
+	if author == event.GetSender().GetLogin() {
+		return
+	}
+
+	if event.GetAction() != actionCreated {
+		return
+	}
+
+	authorUserID := p.getGitHubToUserIDMapping(author)
+	if authorUserID == "" {
+		return
+	}
+
+	if event.GetRepo().GetPrivate() && !p.permissionToRepo(authorUserID, event.GetRepo().GetFullName()) {
+		return
+	}
+
+	if p.senderMutedByReceiver(authorUserID, event.GetSender().GetLogin()) {
+		return
+	}
+
+	message, err := renderTemplate("reviewCommentAuthorNotification", event)
+	if err != nil {
+		p.client.Log.Warn("Failed to render template", "error", err.Error())
+		return
+	}
+
+	p.CreateBotDMPost(authorUserID, message, "custom_git_author")
+	p.sendRefreshEvent(authorUserID)
 }
 
 func (p *Plugin) handleCommentMentionNotification(event *github.IssueCommentEvent) {
@@ -1205,6 +1300,11 @@ func (p *Plugin) handleCommentAuthorNotification(event *github.IssueCommentEvent
 }
 
 func (p *Plugin) handleCommentAssigneeNotification(event *github.IssueCommentEvent) {
+	action := event.GetAction()
+	if action == actionEdited || action == actionDeleted {
+		return
+	}
+
 	author := event.GetIssue().GetUser().GetLogin()
 	assignees := event.GetIssue().Assignees
 	repoName := event.GetRepo().GetFullName()

--- a/server/plugin/webhook_test.go
+++ b/server/plugin/webhook_test.go
@@ -484,8 +484,13 @@ func TestPostPullRequestReviewCommentEvent(t *testing.T) {
 		setup func(*plugintest.API, *mocks.MockKvStore)
 	}{
 		{
+			name:  "Non-created action is ignored",
+			event: GetMockPullRequestReviewCommentEvent(actionEdited, "body", MockUserLogin),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
 			name:  "No subscriptions found",
-			event: GetMockPullRequestReviewCommentEvent(),
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "This is a review comment", MockUserLogin),
 			setup: func(_ *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockKVStore.EXPECT().Get(SubscriptionsKey, mock.MatchedBy(func(val any) bool {
 					_, ok := val.(**Subscriptions)
@@ -495,7 +500,7 @@ func TestPostPullRequestReviewCommentEvent(t *testing.T) {
 		},
 		{
 			name:  "Error creating post",
-			event: GetMockPullRequestReviewCommentEvent(),
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "This is a review comment", MockUserLogin),
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(nil, &model.AppError{Message: "error creating post"}).Times(1)
@@ -503,8 +508,8 @@ func TestPostPullRequestReviewCommentEvent(t *testing.T) {
 			},
 		},
 		{
-			name:  "Successful handling of pull request review comment event",
-			event: GetMockPullRequestReviewCommentEvent(),
+			name:  "Successful handling of created review comment event",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "This is a review comment", MockUserLogin),
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockSubscription(mockKVStore)
 				mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{}, nil).Times(1)
@@ -520,6 +525,154 @@ func TestPostPullRequestReviewCommentEvent(t *testing.T) {
 			tc.setup(mockAPI, mockKVStore)
 
 			p.postPullRequestReviewCommentEvent(tc.event)
+
+			mockAPI.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHandleReviewCommentMentionNotification(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *github.PullRequestReviewCommentEvent
+		setup func(*plugintest.API, *mocks.MockKvStore)
+	}{
+		{
+			name:  "Unsupported action edited",
+			event: GetMockPullRequestReviewCommentEvent(actionEdited, "mention @otherUser", MockUserLogin),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Commenter is the same as mentioned user",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "mention @mockUser", MockUserLogin),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Mentioned user is PR author (handled separately)",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "mention @issueAuthor", MockUserLogin),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Mentioned user not mapped to Mattermost",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "mention @otherUser", MockUserLogin),
+			setup: func(_ *plugintest.API, mockKVStore *mocks.MockKvStore) {
+				mockKVStore.EXPECT().Get("otherUser_githubusername", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).Return(nil).Times(1)
+			},
+		},
+		{
+			name:  "Successful mention notification",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "mention @otherUser", MockUserLogin),
+			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
+				mockKVStore.EXPECT().Get("otherUser_githubusername", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).DoAndReturn(setByteValue("otherUserID")).Times(1)
+				mockKVStore.EXPECT().Get("otherUserID-muted-users", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).Return(nil).Times(1)
+				mockKVStore.EXPECT().Get("otherUserID_githubtoken", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(**GitHubUserInfo)
+					return ok
+				})).Return(nil).Times(1)
+				mockAPI.On("GetDirectChannel", "otherUserID", "mockBotID").Return(&model.Channel{Id: "mockChannelID"}, nil).Times(1)
+				mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{}, nil).Times(1)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockKVStore, mockAPI, _, _, _ := GetTestSetup(t)
+			p := getPluginTest(mockAPI, mockKVStore)
+
+			mockAPI.ExpectedCalls = nil
+			tc.setup(mockAPI, mockKVStore)
+
+			p.handleReviewCommentMentionNotification(tc.event)
+
+			mockAPI.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHandleReviewCommentAuthorNotification(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *github.PullRequestReviewCommentEvent
+		setup func(*plugintest.API, *mocks.MockKvStore)
+	}{
+		{
+			name:  "Unsupported action edited",
+			event: GetMockPullRequestReviewCommentEvent(actionEdited, "body", MockUserLogin),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Sender is the PR author",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockIssueAuthor),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Author not mapped to Mattermost",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
+			setup: func(_ *plugintest.API, mockKVStore *mocks.MockKvStore) {
+				mockKVStore.EXPECT().Get("issueAuthor_githubusername", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).Return(nil).Times(1)
+			},
+		},
+		{
+			name:  "Successful author notification",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
+			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
+				mockKVStore.EXPECT().Get("issueAuthor_githubusername", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).DoAndReturn(setByteValue("authorUserID")).Times(1)
+				mockKVStore.EXPECT().Get("authorUserID-muted-users", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).Return(nil).Times(1)
+				mockKVStore.EXPECT().Get("authorUserID_githubtoken", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(**GitHubUserInfo)
+					return ok
+				})).Return(nil).Times(1)
+				mockAPI.On("GetDirectChannel", "authorUserID", "mockBotID").Return(&model.Channel{Id: "mockChannelID"}, nil).Times(1)
+				mockAPI.On("CreatePost", mock.Anything).Return(&model.Post{}, nil).Times(1)
+			},
+		},
+		{
+			name:  "Muted sender suppresses author notification",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
+			setup: func(_ *plugintest.API, mockKVStore *mocks.MockKvStore) {
+				mockKVStore.EXPECT().Get("issueAuthor_githubusername", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).DoAndReturn(setByteValue("authorUserID")).Times(1)
+				mockKVStore.EXPECT().Get("authorUserID-muted-users", mock.MatchedBy(func(val any) bool {
+					_, ok := val.(*[]uint8)
+					return ok
+				})).DoAndReturn(func(key string, value any) error {
+					if v, ok := value.(*[]byte); ok {
+						*v = []byte(MockUserLogin)
+					}
+					return nil
+				}).Times(1)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockKVStore, mockAPI, _, _, _ := GetTestSetup(t)
+			p := getPluginTest(mockAPI, mockKVStore)
+
+			mockAPI.ExpectedCalls = nil
+			tc.setup(mockAPI, mockKVStore)
+
+			p.handleReviewCommentAuthorNotification(tc.event)
 
 			mockAPI.AssertExpectations(t)
 		})
@@ -762,6 +915,16 @@ func TestHandleCommentAssigneeNotification(t *testing.T) {
 		event *github.IssueCommentEvent
 		setup func(*plugintest.API, *mocks.MockKvStore)
 	}{
+		{
+			name:  "Edited action is ignored",
+			event: GetMockIssueCommentEventWithAssignees("pull", actionEdited, "mockBody", "mockUser", []string{"assigneeUser"}),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Deleted action is ignored",
+			event: GetMockIssueCommentEventWithAssignees("pull", actionDeleted, "mockBody", "mockUser", []string{"assigneeUser"}),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
 		{
 			name:  "Unsupported issue type",
 			event: GetMockIssueCommentEventWithAssignees("mockType", actionCreated, "mockBody", "mockUser", []string{"assigneeUser"}),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR mainly does two things to improve the general experience of receiving DM notifications from the GitHub bot
- Preventing edit or delete PR message events from sending a "new comment" DM notification
- Improving logic that cleans body to prevent issues with html comments in the message from interfering with visibility of message

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68829

#### QA Notes
The main webhook event affected by this is the PR commenting, which mainly consists of:
- Notification received by someone who was mentioned in a PR comment (that is neither the author nor the user posting the comment)
- Notification received by the author of the PR 

We'll want to make sure that editing a PR comment does not send a new notification to the users as a DM

We might also want to run some regression tests on the following DM notifications to confirm they still append a quote with the body of the comment as well:
- commentMentionNotification — DMs users @mentioned in an issue
- commentAuthorIssueNotification — DMs the issue author when someone comments on their issue
- commentAssigneePullRequestNotification — DMs PR assignees when someone comments on the PR conversation
- commentAssigneeIssueNotification — DMs issue assignees when someone comments on the issue
- commentAssigneeSelfMentionPullRequestNotification — DMs PR assignees who were also @mentioned in the comment
- commentAssigneeSelfMentionIssueNotification — DMs issue assignees who were also @mentioned in the comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The PR adds new DM notification handlers for PR review comments and updates message-body cleaning logic used across multiple DM templates; these are user-facing changes spanning several files (webhook handling, templates, and tests) but remain focused on notification behavior.

**Regression Risk:** Moderate. Early-return guards reduce unwanted DMs, but new code paths (user mapping, permission checks, muted-user filtering, and DM posting) introduce failure points that could silently suppress or misroute notifications. The new cleanBody helper changes message rendering for many templates; while templates were updated, dedicated tests for all template output permutations appear limited.

** QA Recommendation:** Perform targeted manual QA on PR comment workflows: verify that editing or deleting PR comments no longer sends "new comment" DMs, and confirm quoted comment bodies are correctly cleaned/omitted for the affected notification types (commentMentionNotification, commentAuthorIssueNotification, commentAssigneePullRequestNotification, commentAssigneeIssueNotification, commentAssigneeSelfMentionPullRequestNotification, commentAssigneeSelfMentionIssueNotification). Automated tests cover many scenarios but manual verification is recommended for edge cases (HTML comments, GitHub footer removal, and permission/mapping failures).

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-github/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->