### PR TITLE
MM-69257 Update option text to indicate GitHub Organization is required for digest

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -146,7 +146,7 @@
                 "key": "OverdueReviewsChannelID",
                 "display_name": "Post overdue review alerts to channel (ID):",
                 "type": "text",
-                "help_text": "Optional. Paste a channel ID (Channel menu > View Info). When set together with PR review target (days), the plugin posts one aggregated overdue-review digest to this channel each day shortly after midnight in the server local timezone (the GitHub bot must be a member of the channel)."
+                "help_text": "Optional. Paste a channel ID (Channel menu > View Info). When set together with PR review target (days) and GitHub Organizations, the plugin posts one aggregated overdue-review digest for those orgs to this channel each day shortly after midnight in the server local timezone. Requires at least one user connected via /github connect. The GitHub bot must be a member of the channel."
             }
         ],
         "footer": "* To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-github)."


### PR DESCRIPTION
#### Summary

2.7.1 made a change to fix a couple of issues with the digest but we didn't update the option text.

Issues:

1. Only Mattermost users who had logged into GitHub would be present in the digest
2. Digests would contain PRs from all Orgs/non-orgs for users logged in

To address this, we use the *GitHub Organization* to make a single QueryJS call, which is also more efficient. But the digest option doesn't call out that it is required. This changes the text to:

> Optional. Paste a channel ID (Channel menu > View Info). When set together with PR review target (days) and GitHub Organizations, the plugin posts one aggregated overdue-review digest for those orgs to this channel each day shortly after midnight in the server local timezone. Requires at least one user connected via /github connect. The GitHub bot must be a member of the channel.

#### Documentation change
We should update docs.mattermost.com's [integrations-guide/github](https://docs.mattermost.com/integrations-guide/github.html#mattermost-configuration) to explain the new PR target and PR digest options.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69257



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This change only updates help text in the plugin.json configuration schema to clarify that GitHub Organizations is required for the digest feature to work. No functional code is altered, and the modification is purely informational.

**Regression Risk:** Minimal. The change is limited to a documentation string within the plugin configuration schema. No code paths, business logic, data handling, or configuration behavior are affected. Existing functionality remains unchanged.

**QA Recommendation:** Manual QA can be skipped entirely. This is a documentation/help text update that doesn't affect feature behavior. Basic verification that the updated help text displays correctly in the plugin settings UI would be sufficient if desired, but is not necessary for release safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->