### PR TITLE
feat: add repository filter dropdown in RHS sidebar

### DIFF
--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -81,6 +81,15 @@ export default class SidebarRight extends React.PureComponent {
         }).isRequired,
     };
 
+    constructor(props) {
+        super(props);
+        this.state = {selectedRepo: ''};
+    }
+
+    handleRepoFilterChange = (e) => {
+        this.setState({selectedRepo: e.target.value});
+    }
+
     componentDidMount() {
         if (this.props.yourPrs && this.props.rhsState === RHSStates.PRS) {
             this.props.actions.getYourPrsDetails(mapGithubItemListToPrList(this.props.yourPrs));
@@ -92,6 +101,11 @@ export default class SidebarRight extends React.PureComponent {
     }
 
     componentDidUpdate(prevProps) {
+        // Reset repo filter when switching RHS tabs
+        if (prevProps.rhsState !== this.props.rhsState) {
+            this.setState({selectedRepo: ''});
+        }
+
         if (shouldUpdateDetails(this.props.yourPrs, prevProps.yourPrs, RHSStates.PRS, this.props.rhsState, prevProps.rhsState)) {
             this.props.actions.getYourPrsDetails(mapGithubItemListToPrList(this.props.yourPrs));
         }
@@ -134,16 +148,41 @@ export default class SidebarRight extends React.PureComponent {
             githubItems = unreads;
             title = 'Unread Messages';
             listUrl = baseURL + '/notifications';
+
             break;
         case RHSStates.ASSIGNMENTS:
 
             githubItems = yourAssignments;
             title = 'Your Assignments';
             listUrl = baseURL + '/pulls?q=is%3Aopen+archived%3Afalse+assignee%3A' + username + orgQuery;
+
             break;
         default:
             break;
         }
+
+        // Extract unique repo names for filter dropdown
+        const repoNames = [...new Set(
+            githubItems.map((item) => {
+                if (item.repository_url) {
+                    return item.repository_url.replace(/.+\/repos\//, '');
+                } else if (item.repository?.full_name) {
+                    return item.repository.full_name;
+                }
+                return null;
+            }).filter(Boolean),
+        )].sort();
+
+        // Filter items by selected repo
+        const {selectedRepo} = this.state;
+        const filteredItems = selectedRepo ?
+            githubItems.filter((item) => {
+                const repoName = item.repository_url ?
+                    item.repository_url.replace(/.+\/repos\//, '') :
+                    item.repository?.full_name;
+                return repoName === selectedRepo;
+            }) :
+            githubItems;
 
         return (
             <React.Fragment>
@@ -163,10 +202,22 @@ export default class SidebarRight extends React.PureComponent {
                                 rel='noopener noreferrer'
                             >{title}</a>
                         </strong>
+                        {repoNames.length > 1 && (
+                            <select
+                                value={selectedRepo}
+                                onChange={this.handleRepoFilterChange}
+                                style={style.repoFilter}
+                            >
+                                <option value=''>All repositories</option>
+                                {repoNames.map((repo) => (
+                                    <option key={repo} value={repo}>{repo}</option>
+                                ))}
+                            </select>
+                        )}
                     </div>
                     <div>
                         <GithubItems
-                            items={githubItems}
+                            items={filteredItems}
                             theme={this.props.theme}
                             showReviewSLA={rhsState === RHSStates.REVIEWS}
                             reviewTargetDays={this.props.reviewTargetDays || 0}
@@ -181,5 +232,13 @@ export default class SidebarRight extends React.PureComponent {
 const style = {
     sectionHeader: {
         padding: '15px',
+    },
+    repoFilter: {
+        marginLeft: '8px',
+        padding: '2px 4px',
+        fontSize: '12px',
+        borderRadius: '4px',
+        border: '1px solid rgba(0, 0, 0, 0.2)',
+        background: 'transparent',
     },
 };

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -4,10 +4,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scrollbars from 'react-custom-scrollbars-2';
+import ReactSelect from 'react-select';
 
-import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
+import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
 
 import {RHSStates} from '../../constants';
+import {getStyleForReactSelect} from '@/utils/styles';
 
 import GithubItems from './github_items';
 
@@ -95,8 +97,8 @@ export default class SidebarRight extends React.PureComponent {
         this.state = {selectedRepo: ''};
     }
 
-    handleRepoFilterChange = (e) => {
-        this.setState({selectedRepo: e.target.value});
+    handleRepoFilterChange = (selectedOption) => {
+        this.setState({selectedRepo: selectedOption ? selectedOption.value : ''});
     }
 
     componentDidMount() {
@@ -112,7 +114,18 @@ export default class SidebarRight extends React.PureComponent {
     componentDidUpdate(prevProps) {
         // Reset repo filter when switching RHS tabs
         if (prevProps.rhsState !== this.props.rhsState) {
-            this.setState({selectedRepo: ''});
+            this.setState({selectedRepo: ''}); // eslint-disable-line react/no-did-update-set-state
+        }
+
+        // Validate selectedRepo against the current list — reset if the repo
+        // is no longer present (stale state when the underlying data changes)
+        if (this.state.selectedRepo) {
+            const currentRepos = [...new Set(
+                this.getCurrentItems().map(getRepoName).filter(Boolean),
+            )];
+            if (!currentRepos.includes(this.state.selectedRepo)) {
+                this.setState({selectedRepo: ''}); // eslint-disable-line react/no-did-update-set-state
+            }
         }
 
         if (shouldUpdateDetails(this.props.yourPrs, prevProps.yourPrs, RHSStates.PRS, this.props.rhsState, prevProps.rhsState)) {
@@ -121,6 +134,22 @@ export default class SidebarRight extends React.PureComponent {
 
         if (shouldUpdateDetails(this.props.reviews, prevProps.reviews, RHSStates.REVIEWS, this.props.rhsState, prevProps.rhsState)) {
             this.props.actions.getReviewsDetails(mapGithubItemListToPrList(this.props.reviews));
+        }
+    }
+
+    getCurrentItems = () => {
+        const {yourPrs, reviews, unreads, yourAssignments, rhsState} = this.props;
+        switch (rhsState) {
+        case RHSStates.PRS:
+            return yourPrs || [];
+        case RHSStates.REVIEWS:
+            return reviews || [];
+        case RHSStates.UNREADS:
+            return unreads || [];
+        case RHSStates.ASSIGNMENTS:
+            return yourAssignments || [];
+        default:
+            return [];
         }
     }
 
@@ -175,8 +204,15 @@ export default class SidebarRight extends React.PureComponent {
             githubItems.map(getRepoName).filter(Boolean),
         )].sort();
 
+        // Build react-select options
+        const repoOptions = [
+            {value: '', label: 'All repositories'},
+            ...repoNames.map((repo) => ({value: repo, label: repo})),
+        ];
+
         // Filter items by selected repo
         const {selectedRepo} = this.state;
+        const selectedOption = repoOptions.find((opt) => opt.value === selectedRepo) || repoOptions[0];
         const filteredItems = selectedRepo ?
             githubItems.filter((item) => getRepoName(item) === selectedRepo) :
             githubItems;
@@ -202,17 +238,18 @@ export default class SidebarRight extends React.PureComponent {
                             >{title}</a>
                         </strong>
                         {repoNames.length > 1 && (
-                            <select
-                                value={selectedRepo}
-                                onChange={this.handleRepoFilterChange}
-                                style={style.repoFilter}
-                                aria-label='Filter by repository'
-                            >
-                                <option value=''>All repositories</option>
-                                {repoNames.map((repo) => (
-                                    <option key={repo} value={repo}>{repo}</option>
-                                ))}
-                            </select>
+                            <div style={style.repoFilterContainer}>
+                                <ReactSelect
+                                    value={selectedOption}
+                                    onChange={this.handleRepoFilterChange}
+                                    options={repoOptions}
+                                    styles={getStyleForReactSelect(this.props.theme)}
+                                    aria-label='Filter by repository'
+                                    isSearchable={false}
+                                    menuPortalTarget={document.body}
+                                    menuPlacement='auto'
+                                />
+                            </div>
                         )}
                     </div>
                     <div>
@@ -234,14 +271,11 @@ const getStyle = makeStyleFromTheme((theme) => {
         sectionHeader: {
             padding: '15px',
         },
-        repoFilter: {
+        repoFilterContainer: {
             marginLeft: '8px',
-            padding: '2px 4px',
+            minWidth: '160px',
+            maxWidth: '220px',
             fontSize: '12px',
-            borderRadius: '4px',
-            border: `1px solid ${changeOpacity(theme.centerChannelColor, 0.2)}`,
-            background: 'transparent',
-            color: theme.centerChannelColor,
         },
     };
 });

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Scrollbars from 'react-custom-scrollbars-2';
 
+import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
+
 import {RHSStates} from '../../constants';
 
 import GithubItems from './github_items';
@@ -41,6 +43,13 @@ function mapGithubItemListToPrList(gilist) {
     return gilist.map((pr) => {
         return {url: pr.repository_url, number: pr.number};
     });
+}
+
+function getRepoName(item) {
+    if (item.repository_url) {
+        return item.repository_url.replace(/.+\/repos\//, '');
+    }
+    return item.repository?.full_name ?? null;
 }
 
 function shouldUpdateDetails(prs, prevPrs, targetState, currentState, prevState) {
@@ -163,26 +172,16 @@ export default class SidebarRight extends React.PureComponent {
 
         // Extract unique repo names for filter dropdown
         const repoNames = [...new Set(
-            githubItems.map((item) => {
-                if (item.repository_url) {
-                    return item.repository_url.replace(/.+\/repos\//, '');
-                } else if (item.repository?.full_name) {
-                    return item.repository.full_name;
-                }
-                return null;
-            }).filter(Boolean),
+            githubItems.map(getRepoName).filter(Boolean),
         )].sort();
 
         // Filter items by selected repo
         const {selectedRepo} = this.state;
         const filteredItems = selectedRepo ?
-            githubItems.filter((item) => {
-                const repoName = item.repository_url ?
-                    item.repository_url.replace(/.+\/repos\//, '') :
-                    item.repository?.full_name;
-                return repoName === selectedRepo;
-            }) :
+            githubItems.filter((item) => getRepoName(item) === selectedRepo) :
             githubItems;
+
+        const style = getStyle(this.props.theme);
 
         return (
             <React.Fragment>
@@ -207,6 +206,7 @@ export default class SidebarRight extends React.PureComponent {
                                 value={selectedRepo}
                                 onChange={this.handleRepoFilterChange}
                                 style={style.repoFilter}
+                                aria-label='Filter by repository'
                             >
                                 <option value=''>All repositories</option>
                                 {repoNames.map((repo) => (
@@ -229,16 +229,19 @@ export default class SidebarRight extends React.PureComponent {
     }
 }
 
-const style = {
-    sectionHeader: {
-        padding: '15px',
-    },
-    repoFilter: {
-        marginLeft: '8px',
-        padding: '2px 4px',
-        fontSize: '12px',
-        borderRadius: '4px',
-        border: '1px solid rgba(0, 0, 0, 0.2)',
-        background: 'transparent',
-    },
-};
+const getStyle = makeStyleFromTheme((theme) => {
+    return {
+        sectionHeader: {
+            padding: '15px',
+        },
+        repoFilter: {
+            marginLeft: '8px',
+            padding: '2px 4px',
+            fontSize: '12px',
+            borderRadius: '4px',
+            border: `1px solid ${changeOpacity(theme.centerChannelColor, 0.2)}`,
+            background: 'transparent',
+            color: theme.centerChannelColor,
+        },
+    };
+});


### PR DESCRIPTION
## Summary
Adds a repository filter dropdown to the GitHub plugin RHS sidebar, allowing users to filter PRs, reviews, assignments, and unread notifications by specific repository.

Resolves #265

## Changes
- Added a `<select>` dropdown in the RHS header that lists all unique repositories from the current items
- When a repo is selected, items are filtered to only show entries from that repository
- Filter resets when switching between RHS tabs (PRs, Reviews, Unreads, Assignments)
- Dropdown only appears when there are multiple repositories in the list

## Release Notes
```release-note-none
```

## Screenshots
The dropdown appears next to the title in the RHS header, styled minimally to match the existing UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The change is isolated to a single sidebar component, but it alters user-facing filtering behavior and introduces new state-driven rendering paths that need validation across the four RHS views. It doesn’t touch shared infrastructure or critical backend flows, but it does affect an important interaction in a widely used UI surface.

**Regression Risk:** Moderate. The main risk is incorrect filtering or reset behavior when switching tabs, especially for edge cases with empty lists, duplicate repo names, or theme-dependent styling.

**QA Recommendation:** Perform targeted manual QA on each RHS tab to verify repository dropdown visibility, option population, filtering, and reset behavior when changing tabs. Low risk to skip broad regression testing, but this specific sidebar flow should be checked before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->