### PR TITLE
feat: add sort toggle for RHS items (Created vs Updated)

### DIFF
--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -5,9 +5,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Scrollbars from 'react-custom-scrollbars-2';
 
+import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
+
 import {RHSStates} from '../../constants';
 
 import GithubItems from './github_items';
+import SortDropdown from './sort_dropdown';
 
 export function renderView(props) {
     return (
@@ -81,6 +84,15 @@ export default class SidebarRight extends React.PureComponent {
         }).isRequired,
     };
 
+    constructor(props) {
+        super(props);
+        this.state = {sortBy: 'created'};
+    }
+
+    handleSortChange = (selectedOption) => {
+        this.setState({sortBy: selectedOption ? selectedOption.value : 'created'});
+    };
+
     componentDidMount() {
         if (this.props.yourPrs && this.props.rhsState === RHSStates.PRS) {
             this.props.actions.getYourPrsDetails(mapGithubItemListToPrList(this.props.yourPrs));
@@ -145,6 +157,25 @@ export default class SidebarRight extends React.PureComponent {
             break;
         }
 
+        // Sort items by selected criteria
+        // Notification threads (UNREADS) don't have created_at, so fall back
+        // to updated_at when created_at is undefined.
+        const {sortBy} = this.state;
+        const sortedItems = (githubItems || []).slice().sort((a, b) => {
+            const dateA = sortBy === 'updated' ? a.updated_at : (a.created_at || a.updated_at);
+            const dateB = sortBy === 'updated' ? b.updated_at : (b.created_at || b.updated_at);
+            return new Date(dateB) - new Date(dateA);
+        });
+
+        // Build sort options
+        const sortOptions = [
+            {value: 'created', label: 'Recently Created'},
+            {value: 'updated', label: 'Recently Updated'},
+        ];
+        const selectedSortOption = sortOptions.find((opt) => opt.value === sortBy) || sortOptions[0];
+
+        const style = getStyle(this.props.theme);
+
         return (
             <React.Fragment>
                 <Scrollbars
@@ -163,10 +194,19 @@ export default class SidebarRight extends React.PureComponent {
                                 rel='noopener noreferrer'
                             >{title}</a>
                         </strong>
+                        <div style={style.sortDropdownContainer}>
+                            <SortDropdown
+                                value={selectedSortOption}
+                                onChange={this.handleSortChange}
+                                options={sortOptions}
+                                theme={this.props.theme}
+                                ariaLabel='Sort items'
+                            />
+                        </div>
                     </div>
                     <div>
                         <GithubItems
-                            items={githubItems}
+                            items={sortedItems}
                             theme={this.props.theme}
                             showReviewSLA={rhsState === RHSStates.REVIEWS}
                             reviewTargetDays={this.props.reviewTargetDays || 0}
@@ -178,8 +218,19 @@ export default class SidebarRight extends React.PureComponent {
     }
 }
 
-const style = {
-    sectionHeader: {
-        padding: '15px',
-    },
-};
+const getStyle = makeStyleFromTheme(() => {
+    return {
+        sectionHeader: {
+            padding: '15px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+        },
+        sortDropdownContainer: {
+            marginLeft: '8px',
+            width: 'fit-content',
+            fontSize: '12px',
+        },
+    };
+});

--- a/webapp/src/components/sidebar_right/sort_dropdown.jsx
+++ b/webapp/src/components/sidebar_right/sort_dropdown.jsx
@@ -1,0 +1,315 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Overlay} from 'react-bootstrap';
+import {ChevronDownIcon, ChevronUpIcon, CheckIcon} from '@primer/octicons-react';
+
+import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
+
+export default class SortDropdown extends React.PureComponent {
+    static propTypes = {
+        value: PropTypes.shape({
+            value: PropTypes.string.isRequired,
+            label: PropTypes.string.isRequired,
+        }).isRequired,
+        onChange: PropTypes.func.isRequired,
+        options: PropTypes.arrayOf(PropTypes.shape({
+            value: PropTypes.string.isRequired,
+            label: PropTypes.string.isRequired,
+        })).isRequired,
+        theme: PropTypes.object.isRequired,
+        ariaLabel: PropTypes.string,
+        className: PropTypes.string,
+    };
+
+    static defaultProps = {
+        ariaLabel: 'Sort items',
+        className: '',
+    };
+
+    constructor(props) {
+        super(props);
+        this.state = {isOpen: false, hoveredOption: null, isTriggerFocused: false};
+        this.toggleRef = React.createRef();
+    }
+
+    handleTriggerFocus = () => {
+        this.setState({isTriggerFocused: true});
+    };
+
+    handleTriggerBlur = () => {
+        this.setState({isTriggerFocused: false});
+    };
+
+    handleToggle = () => {
+        this.setState(({isOpen}) => ({isOpen: !isOpen}));
+    };
+
+    handleClose = () => {
+        this.setState({isOpen: false, hoveredOption: null});
+    };
+
+    handleOptionClick = (option) => {
+        this.props.onChange(option);
+        this.handleClose();
+    };
+
+    handleKeyDown = (event) => {
+        const {options, value} = this.props;
+        const currentIndex = options.findIndex((opt) => opt.value === value.value);
+        let newIndex = currentIndex;
+
+        switch (event.key) {
+        case 'ArrowDown':
+            event.preventDefault();
+            newIndex = (currentIndex + 1) % options.length;
+            break;
+        case 'ArrowUp':
+            event.preventDefault();
+            newIndex = ((currentIndex - 1) + options.length) % options.length;
+            break;
+        case 'Enter':
+        case ' ':
+            event.preventDefault();
+            this.handleToggle();
+            return;
+        case 'Escape':
+            this.handleClose();
+            return;
+        default:
+            return;
+        }
+
+        if (newIndex !== currentIndex) {
+            this.props.onChange(options[newIndex]);
+        }
+    };
+
+    render() {
+        const {value, options, theme, ariaLabel, className} = this.props;
+        const {isOpen, hoveredOption, isTriggerFocused} = this.state;
+        const style = getStyle(theme);
+
+        const trigger = (
+            <button
+                ref={this.toggleRef}
+                type='button'
+                style={{
+                    ...style.trigger,
+                    ...(isTriggerFocused ? style.triggerFocused : {}),
+                }}
+                onClick={this.handleToggle}
+                onKeyDown={this.handleKeyDown}
+                onFocus={this.handleTriggerFocus}
+                onBlur={this.handleTriggerBlur}
+                aria-haspopup='listbox'
+                aria-expanded={isOpen}
+                aria-label={`Sort by: ${value.label}`}
+                className={className}
+            >
+                <span style={style.triggerText}>
+                    {'Sort by: '}
+                    {value.label}
+                </span>
+                <span style={style.chevronContainer}>
+                    {isOpen ? (
+                        <ChevronUpIcon
+                            size={12}
+                            style={style.chevron}
+                            aria-hidden='true'
+                        />
+                    ) : (
+                        <ChevronDownIcon
+                            size={12}
+                            style={style.chevron}
+                            aria-hidden='true'
+                        />
+                    )}
+                </span>
+            </button>
+        );
+
+        const overlay = (
+            <Overlay
+                show={isOpen}
+                onHide={this.handleClose}
+                target={this.toggleRef}
+                placement='bottom-start'
+                rootClose={true}
+            >
+                <div style={style.popover}>
+                    <ul
+                        style={style.optionsList}
+                        role='listbox'
+                        aria-label={ariaLabel}
+                    >
+                        {options.map((option) => {
+                            const isSelected = option.value === value.value;
+                            const isHovered = option.value === hoveredOption;
+                            return (
+                                <li
+                                    key={option.value}
+                                    role='option'
+                                    aria-selected={isSelected}
+                                    style={{
+                                        ...style.option,
+                                        ...(isSelected ? style.optionSelected : {}),
+                                        ...(isHovered && !isSelected ? style.optionHover : {}),
+                                    }}
+                                    onClick={() => this.handleOptionClick(option)}
+                                    onMouseEnter={() => this.setState({hoveredOption: option.value})}
+                                    onMouseLeave={() => this.setState({hoveredOption: null})}
+                                    onFocus={() => this.setState({hoveredOption: option.value})}
+                                    onBlur={() => this.setState({hoveredOption: null})}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter' || e.key === ' ') {
+                                            e.preventDefault();
+                                            this.handleOptionClick(option);
+                                        }
+                                    }}
+                                    tabIndex={isSelected ? 0 : -1}
+                                >
+                                    <span style={style.optionLabel}>
+                                        <CheckIcon
+                                            size={16}
+                                            style={isSelected ? style.optionIconSelected : style.optionIcon}
+                                            aria-hidden='true'
+                                        />
+                                        <span style={isSelected ? style.optionTextSelected : style.optionText}>
+                                            {option.label}
+                                        </span>
+                                    </span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            </Overlay>
+        );
+
+        return (
+            <div style={style.container}>
+                {trigger}
+                {overlay}
+            </div>
+        );
+    }
+}
+
+const getStyle = makeStyleFromTheme((theme) => {
+    const textColor = theme.centerChannelColor;
+    const bgColor = theme.centerChannelBg;
+
+    const text56 = changeOpacity(textColor, 0.56);
+    const text8 = changeOpacity(textColor, 0.08);
+
+    return {
+        container: {
+            display: 'inline-flex',
+            alignItems: 'center',
+        },
+
+        // Select trigger — "Sort by: Recently Created"
+        // font: Open Sans 12px/16px semibold, color rgba(61,60,64,0.56)
+        trigger: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '4px',
+            padding: 0,
+            border: 'none',
+            borderRadius: 0,
+            background: 'transparent',
+            color: text56,
+            fontFamily: '"Open Sans", sans-serif',
+            fontSize: '12px',
+            fontStyle: 'normal',
+            fontWeight: 600,
+            lineHeight: '16px',
+            textAlign: 'center',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+        },
+        triggerFocused: {
+            outline: `2px solid ${textColor}`,
+            outlineOffset: '2px',
+        },
+        triggerText: {
+            display: 'inline',
+        },
+        chevronContainer: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            flexShrink: 0,
+        },
+        chevron: {
+            color: text56,
+        },
+
+        // Popover — display:inline-flex, padding:8px 0, flex-direction:column, align-items:flex-start
+        // border-radius:4px, border:1px solid rgba(61,60,64,0.08), background:#FFF
+        // box-shadow: Elevation 4 = 0 8px 24px 0 rgba(0,0,0,0.12)
+        popover: {
+            position: 'relative',
+            display: 'inline-flex',
+            padding: '8px 0',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            background: bgColor,
+            border: `1px solid ${text8}`,
+            borderRadius: '4px',
+            boxShadow: '0 8px 24px 0 rgba(0, 0, 0, 0.12)',
+            minWidth: '200px',
+            zIndex: 9999,
+            marginTop: '4px',
+        },
+        optionsList: {
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            maxHeight: '300px',
+            overflowY: 'auto',
+        },
+        option: {
+            height: '32px',
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0 20px',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+            transition: 'background 0.1s ease',
+        },
+        optionHover: {
+            background: text8,
+            outline: 'none',
+        },
+        optionSelected: {
+            background: textColor,
+        },
+        optionLabel: {
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '12px',
+            padding: '0 4px',
+        },
+        optionIcon: {
+            color: 'transparent',
+            flexShrink: 0,
+        },
+        optionIconSelected: {
+            color: bgColor,
+            flexShrink: 0,
+        },
+        optionText: {
+            fontSize: '12px',
+            fontWeight: 400,
+            color: textColor,
+        },
+        optionTextSelected: {
+            fontSize: '12px',
+            fontWeight: 400,
+            color: bgColor,
+        },
+    };
+});


### PR DESCRIPTION
## Summary
Adds a sort dropdown to the GitHub plugin RHS sidebar, allowing users to sort items by "Created" (default, existing behavior) or "Updated" date.

Resolves #242

## Changes
- Added a `<select>` dropdown in the RHS header with two options: "Sort: Created" and "Sort: Updated"
- Default is "Created" which preserves existing behavior
- Items are sorted client-side by `created_at` or `updated_at` field (descending)

## Release Notes
```release-note-none
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** This introduces a new, user-facing right-sidebar sorting control and new client-side ordering logic (including `updated_at` fallback behavior), plus a fresh interactive dropdown component with keyboard/ARIA handling. While it doesn’t touch auth/session/data persistence, it can affect rendering and interaction correctness on the RHS across multiple sidebar states.

**Regression Risk:** Moderate — sorting and UI interaction changes are localized to the sidebar components, but date parsing/sorting and dropdown open/close/selection behavior are new paths that could regress in common usage.

**QA Recommendation:** Moderate manual QA recommended: validate default “Recently Created” and “Recently Updated” ordering for PR/review/unread/assignment contexts, confirm unread thread fallback when `created_at` is missing, and test dropdown mouse + keyboard navigation/focus/ARIA across light/dark themes. Skipping manual QA is not advised for the sorting dropdown and ordering behavior.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->