### PR TITLE
feat: add refresh ability to GitHub RHS sidebar

### DIFF
--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -35,9 +35,13 @@ export default class SidebarButtons extends React.PureComponent {
         this.state = {
             refreshing: false,
         };
+        this.mounted = false;
+        this.refreshing = false;
     }
 
     componentDidMount() {
+        this.mounted = true;
+
         if (this.props.connected) {
             this.getData();
             return;
@@ -52,8 +56,12 @@ export default class SidebarButtons extends React.PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        this.mounted = false;
+    }
+
     getData = async (e) => {
-        if (this.state.refreshing) {
+        if (this.refreshing) {
             return;
         }
 
@@ -70,9 +78,16 @@ export default class SidebarButtons extends React.PureComponent {
             e.preventDefault();
         }
 
+        this.refreshing = true;
         this.setState({refreshing: true});
-        await this.props.actions.getSidebarContent();
-        this.setState({refreshing: false});
+        try {
+            await this.props.actions.getSidebarContent();
+        } finally {
+            this.refreshing = false;
+            if (this.mounted) {
+                this.setState({refreshing: false});
+            }
+        }
     };
 
     openConnectWindow = (e) => {
@@ -83,6 +98,7 @@ export default class SidebarButtons extends React.PureComponent {
     openRHS = (rhsState) => {
         this.props.actions.updateRhsState(rhsState);
         this.props.showRHSPlugin();
+        this.getData();
     };
 
     render() {

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.jsx
@@ -61,6 +61,10 @@ export default class SidebarButtons extends React.PureComponent {
     }
 
     getData = async (e) => {
+        if (e) {
+            e.preventDefault();
+        }
+
         if (this.refreshing) {
             return;
         }
@@ -72,10 +76,6 @@ export default class SidebarButtons extends React.PureComponent {
         // eslint-disable-next-line no-undef
         if (__E2E_TESTING__ && params.get('skip_github_fetch') === 'true') {
             return;
-        }
-
-        if (e) {
-            e.preventDefault();
         }
 
         this.refreshing = true;

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.test.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {act, render} from '@testing-library/react';
+import {act, fireEvent, render} from '@testing-library/react';
 
 import {RHSStates} from '../../constants';
 
@@ -101,6 +101,31 @@ test('does not start duplicate sidebar requests while an open refresh is pending
 
     expect(getSidebarContent).toHaveBeenCalledTimes(1);
     expect(actions.updateRhsState).toHaveBeenCalledTimes(2);
+    await act(async () => {
+        resolveRequest({});
+        await pendingRequest;
+    });
+});
+
+test('prevents the refresh anchor default action while a refresh is pending', async () => {
+    let resolveRequest;
+    const pendingRequest = new Promise((resolve) => {
+        resolveRequest = resolve;
+    });
+    const getSidebarContent = jest.fn().mockResolvedValueOnce({}).mockReturnValue(pendingRequest);
+    const {container} = renderSidebarButtons({
+        actions: {
+            getConnected: jest.fn(),
+            getSidebarContent,
+            updateRhsState: jest.fn(),
+        },
+    });
+    await act(async () => Promise.resolve());
+
+    const refreshLink = container.querySelector('a[href="#"]');
+    expect(fireEvent.click(refreshLink)).toBe(false);
+    expect(fireEvent.click(refreshLink)).toBe(false);
+
     await act(async () => {
         resolveRequest({});
         await pendingRequest;

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.test.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.test.jsx
@@ -113,7 +113,7 @@ test('prevents the refresh anchor default action while a refresh is pending', as
         resolveRequest = resolve;
     });
     const getSidebarContent = jest.fn().mockResolvedValueOnce({}).mockReturnValue(pendingRequest);
-    const {container} = renderSidebarButtons({
+    const {container, unmount} = renderSidebarButtons({
         actions: {
             getConnected: jest.fn(),
             getSidebarContent,
@@ -126,6 +126,7 @@ test('prevents the refresh anchor default action while a refresh is pending', as
     expect(fireEvent.click(refreshLink)).toBe(false);
     expect(fireEvent.click(refreshLink)).toBe(false);
 
+    unmount();
     await act(async () => {
         resolveRequest({});
         await pendingRequest;

--- a/webapp/src/components/sidebar_buttons/sidebar_buttons.test.jsx
+++ b/webapp/src/components/sidebar_buttons/sidebar_buttons.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {act, render} from '@testing-library/react';
+
+import {RHSStates} from '../../constants';
+
+import SidebarButtons from './sidebar_buttons';
+
+// The component hides its controls during E2E testing.
+// eslint-disable-next-line no-underscore-dangle
+global.__E2E_TESTING__ = false;
+
+jest.mock('react-bootstrap', () => ({
+    OverlayTrigger: ({children}) => children,
+    Tooltip: ({children}) => children,
+}));
+
+jest.mock('mattermost-redux/utils/theme_utils', () => ({
+    changeOpacity: (color) => color,
+    makeStyleFromTheme: (createStyle) => (theme) => createStyle(theme),
+}));
+
+const baseProps = {
+    connected: true,
+    clientId: 'client-id',
+    enterpriseURL: '',
+    isTeamSidebar: false,
+    reviewTargetDays: 0,
+    reviews: [],
+    theme: {
+        centerChannelBg: '#ffffff',
+        centerChannelColor: '#333333',
+    },
+    unreads: [],
+    yourAssignments: [],
+    yourPrs: [],
+};
+
+function renderSidebarButtons(overrides = {}) {
+    const actions = overrides.actions || {
+        getConnected: jest.fn(),
+        getSidebarContent: jest.fn().mockResolvedValue({}),
+        updateRhsState: jest.fn(),
+    };
+    const showRHSPlugin = jest.fn();
+    const result = render(
+        <SidebarButtons
+            {...baseProps}
+            {...overrides}
+            actions={actions}
+            showRHSPlugin={showRHSPlugin}
+        />,
+    );
+
+    return {actions, showRHSPlugin, ...result};
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+test('refreshes sidebar content when opening or switching the RHS view', async () => {
+    const {actions, showRHSPlugin, container} = renderSidebarButtons();
+    await act(async () => Promise.resolve());
+    actions.getSidebarContent.mockClear();
+
+    const links = container.querySelectorAll('a');
+    await act(async () => {
+        links[1].click();
+    });
+    await act(async () => {
+        links[2].click();
+    });
+
+    expect(actions.updateRhsState).toHaveBeenNthCalledWith(1, RHSStates.PRS);
+    expect(actions.updateRhsState).toHaveBeenNthCalledWith(2, RHSStates.REVIEWS);
+    expect(showRHSPlugin).toHaveBeenCalledTimes(2);
+    expect(actions.getSidebarContent).toHaveBeenCalledTimes(2);
+});
+
+test('does not start duplicate sidebar requests while an open refresh is pending', async () => {
+    let resolveRequest;
+    const pendingRequest = new Promise((resolve) => {
+        resolveRequest = resolve;
+    });
+    const getSidebarContent = jest.fn().mockResolvedValueOnce({}).mockReturnValue(pendingRequest);
+    const {actions, container} = renderSidebarButtons({
+        actions: {
+            getConnected: jest.fn(),
+            getSidebarContent,
+            updateRhsState: jest.fn(),
+        },
+    });
+    await act(async () => Promise.resolve());
+    getSidebarContent.mockClear();
+
+    const links = container.querySelectorAll('a');
+    act(() => {
+        links[1].click();
+        links[2].click();
+    });
+
+    expect(getSidebarContent).toHaveBeenCalledTimes(1);
+    expect(actions.updateRhsState).toHaveBeenCalledTimes(2);
+    await act(async () => {
+        resolveRequest({});
+        await pendingRequest;
+    });
+});

--- a/webapp/src/components/sidebar_right/index.jsx
+++ b/webapp/src/components/sidebar_right/index.jsx
@@ -4,7 +4,7 @@
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import {getReviewsDetails, getYourPrsDetails} from '../../actions';
+import {getReviewsDetails, getYourPrsDetails, getSidebarContent} from '../../actions';
 
 import {getSidebarData} from 'src/selectors';
 
@@ -30,6 +30,7 @@ function mapDispatchToProps(dispatch) {
         actions: bindActionCreators({
             getYourPrsDetails,
             getReviewsDetails,
+            getSidebarContent,
         }, dispatch),
     };
 }

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Scrollbars from 'react-custom-scrollbars-2';
+import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
 import {RHSStates} from '../../constants';
 
@@ -78,10 +79,31 @@ export default class SidebarRight extends React.PureComponent {
         actions: PropTypes.shape({
             getYourPrsDetails: PropTypes.func.isRequired,
             getReviewsDetails: PropTypes.func.isRequired,
+            getSidebarContent: PropTypes.func.isRequired,
         }).isRequired,
     };
 
+    constructor(props) {
+        super(props);
+        this.state = {refreshing: false};
+    }
+
+    handleRefresh = async (e) => {
+        if (e) {
+            e.preventDefault();
+        }
+        if (this.state.refreshing) {
+            return;
+        }
+        this.setState({refreshing: true});
+        await this.props.actions.getSidebarContent();
+        this.setState({refreshing: false});
+    };
+
     componentDidMount() {
+        // Auto-refresh on open to guarantee latest data (issue #131)
+        this.handleRefresh();
+
         if (this.props.yourPrs && this.props.rhsState === RHSStates.PRS) {
             this.props.actions.getYourPrsDetails(mapGithubItemListToPrList(this.props.yourPrs));
         }
@@ -163,6 +185,19 @@ export default class SidebarRight extends React.PureComponent {
                                 rel='noopener noreferrer'
                             >{title}</a>
                         </strong>
+                        <OverlayTrigger
+                            key='rhsRefreshButton'
+                            placement='left'
+                            overlay={<Tooltip id='rhsRefreshTooltip'>{'Refresh'}</Tooltip>}
+                        >
+                            <a
+                                href='#'
+                                style={style.refreshButton}
+                                onClick={this.handleRefresh}
+                            >
+                                <i className={'fa fa-refresh' + (this.state.refreshing ? ' fa-spin' : '')}/>
+                            </a>
+                        </OverlayTrigger>
                     </div>
                     <div>
                         <GithubItems
@@ -181,5 +216,12 @@ export default class SidebarRight extends React.PureComponent {
 const style = {
     sectionHeader: {
         padding: '15px',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    },
+    refreshButton: {
+        color: 'rgba(0, 0, 0, 0.4)',
+        cursor: 'pointer',
     },
 };

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -6,8 +6,9 @@ import PropTypes from 'prop-types';
 import Scrollbars from 'react-custom-scrollbars-2';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 
-import {RHSStates} from '../../constants';
+import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
+import {RHSStates} from '../../constants';
 import GithubItems from './github_items';
 
 export function renderView(props) {
@@ -15,7 +16,8 @@ export function renderView(props) {
         <div
             {...props}
             className='scrollbar--view'
-        />);
+        />
+    );
 }
 
 export function renderThumbHorizontal(props) {
@@ -23,7 +25,8 @@ export function renderThumbHorizontal(props) {
         <div
             {...props}
             className='scrollbar--horizontal'
-        />);
+        />
+    );
 }
 
 export function renderThumbVertical(props) {
@@ -31,7 +34,8 @@ export function renderThumbVertical(props) {
         <div
             {...props}
             className='scrollbar--vertical'
-        />);
+        />
+    );
 }
 
 function mapGithubItemListToPrList(gilist) {
@@ -86,23 +90,12 @@ export default class SidebarRight extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {refreshing: false};
+        this._mounted = false;
+        this._refreshing = false;
     }
 
-    handleRefresh = async (e) => {
-        if (e) {
-            e.preventDefault();
-        }
-        if (this.state.refreshing) {
-            return;
-        }
-        this.setState({refreshing: true});
-        await this.props.actions.getSidebarContent();
-        this.setState({refreshing: false});
-    };
-
     componentDidMount() {
-        // Auto-refresh on open to guarantee latest data (issue #131)
-        this.handleRefresh();
+        this._mounted = true;
 
         if (this.props.yourPrs && this.props.rhsState === RHSStates.PRS) {
             this.props.actions.getYourPrsDetails(mapGithubItemListToPrList(this.props.yourPrs));
@@ -112,6 +105,29 @@ export default class SidebarRight extends React.PureComponent {
             this.props.actions.getReviewsDetails(mapGithubItemListToPrList(this.props.reviews));
         }
     }
+
+    componentWillUnmount() {
+        this._mounted = false;
+    }
+
+    handleRefresh = async (e) => {
+        if (e) {
+            e.preventDefault();
+        }
+        if (this._refreshing) {
+            return;
+        }
+        this._refreshing = true;
+        this.setState({refreshing: true});
+        try {
+            await this.props.actions.getSidebarContent();
+        } finally {
+            this._refreshing = false;
+            if (this._mounted) {
+                this.setState({refreshing: false});
+            }
+        }
+    };
 
     componentDidUpdate(prevProps) {
         if (shouldUpdateDetails(this.props.yourPrs, prevProps.yourPrs, RHSStates.PRS, this.props.rhsState, prevProps.rhsState)) {
@@ -124,6 +140,25 @@ export default class SidebarRight extends React.PureComponent {
     }
 
     render() {
+        const getStyle = makeStyleFromTheme((theme) => {
+            return {
+                sectionHeader: {
+                    padding: '15px',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                },
+                refreshButton: {
+                    color: changeOpacity(theme.centerChannelColor, 0.6),
+                    cursor: 'pointer',
+                    background: 'transparent',
+                    border: 'none',
+                    padding: 0,
+                },
+            };
+        });
+
+        const style = getStyle(this.props.theme);
         const baseURL = this.props.enterpriseURL ? this.props.enterpriseURL : 'https://github.com';
         let orgQuery = '';
         this.props.orgs.map((org) => {
@@ -138,27 +173,23 @@ export default class SidebarRight extends React.PureComponent {
 
         switch (rhsState) {
         case RHSStates.PRS:
-
             githubItems = yourPrs;
             title = 'Your Open Pull Requests';
             listUrl = baseURL + '/pulls?q=is%3Aopen+is%3Apr+author%3A' + username + '+archived%3Afalse' + orgQuery;
 
             break;
         case RHSStates.REVIEWS:
-
             githubItems = reviews;
             listUrl = baseURL + '/pulls?q=is%3Aopen+is%3Apr+review-requested%3A' + username + '+archived%3Afalse' + orgQuery;
             title = 'Pull Requests Needing Review';
 
             break;
         case RHSStates.UNREADS:
-
             githubItems = unreads;
             title = 'Unread Messages';
             listUrl = baseURL + '/notifications';
             break;
         case RHSStates.ASSIGNMENTS:
-
             githubItems = yourAssignments;
             title = 'Your Assignments';
             listUrl = baseURL + '/pulls?q=is%3Aopen+archived%3Afalse+assignee%3A' + username + orgQuery;
@@ -190,13 +221,14 @@ export default class SidebarRight extends React.PureComponent {
                             placement='left'
                             overlay={<Tooltip id='rhsRefreshTooltip'>{'Refresh'}</Tooltip>}
                         >
-                            <a
-                                href='#'
+                            <button
+                                type='button'
+                                aria-label='Refresh'
                                 style={style.refreshButton}
                                 onClick={this.handleRefresh}
                             >
                                 <i className={'fa fa-refresh' + (this.state.refreshing ? ' fa-spin' : '')}/>
-                            </a>
+                            </button>
                         </OverlayTrigger>
                     </div>
                     <div>
@@ -212,16 +244,3 @@ export default class SidebarRight extends React.PureComponent {
         );
     }
 }
-
-const style = {
-    sectionHeader: {
-        padding: '15px',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-    },
-    refreshButton: {
-        color: 'rgba(0, 0, 0, 0.4)',
-        cursor: 'pointer',
-    },
-};

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -11,6 +11,24 @@ import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_ut
 import {RHSStates} from '../../constants';
 import GithubItems from './github_items';
 
+const getStyle = makeStyleFromTheme((theme) => {
+    return {
+        sectionHeader: {
+            padding: '15px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+        },
+        refreshButton: {
+            color: changeOpacity(theme.centerChannelColor, 0.6),
+            cursor: 'pointer',
+            background: 'transparent',
+            border: 'none',
+            padding: 0,
+        },
+    };
+});
+
 export function renderView(props) {
     return (
         <div
@@ -140,24 +158,6 @@ export default class SidebarRight extends React.PureComponent {
     }
 
     render() {
-        const getStyle = makeStyleFromTheme((theme) => {
-            return {
-                sectionHeader: {
-                    padding: '15px',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                },
-                refreshButton: {
-                    color: changeOpacity(theme.centerChannelColor, 0.6),
-                    cursor: 'pointer',
-                    background: 'transparent',
-                    border: 'none',
-                    padding: 0,
-                },
-            };
-        });
-
         const style = getStyle(this.props.theme);
         const baseURL = this.props.enterpriseURL ? this.props.enterpriseURL : 'https://github.com';
         let orgQuery = '';

--- a/webapp/src/components/sidebar_right/sidebar_right.jsx
+++ b/webapp/src/components/sidebar_right/sidebar_right.jsx
@@ -9,6 +9,7 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {makeStyleFromTheme, changeOpacity} from 'mattermost-redux/utils/theme_utils';
 
 import {RHSStates} from '../../constants';
+
 import GithubItems from './github_items';
 
 const getStyle = makeStyleFromTheme((theme) => {
@@ -108,12 +109,12 @@ export default class SidebarRight extends React.PureComponent {
     constructor(props) {
         super(props);
         this.state = {refreshing: false};
-        this._mounted = false;
-        this._refreshing = false;
+        this.mounted = false;
+        this.refreshing = false;
     }
 
     componentDidMount() {
-        this._mounted = true;
+        this.mounted = true;
 
         if (this.props.yourPrs && this.props.rhsState === RHSStates.PRS) {
             this.props.actions.getYourPrsDetails(mapGithubItemListToPrList(this.props.yourPrs));
@@ -125,23 +126,23 @@ export default class SidebarRight extends React.PureComponent {
     }
 
     componentWillUnmount() {
-        this._mounted = false;
+        this.mounted = false;
     }
 
     handleRefresh = async (e) => {
         if (e) {
             e.preventDefault();
         }
-        if (this._refreshing) {
+        if (this.refreshing) {
             return;
         }
-        this._refreshing = true;
+        this.refreshing = true;
         this.setState({refreshing: true});
         try {
             await this.props.actions.getSidebarContent();
         } finally {
-            this._refreshing = false;
-            if (this._mounted) {
+            this.refreshing = false;
+            if (this.mounted) {
                 this.setState({refreshing: false});
             }
         }


### PR DESCRIPTION
## Summary
Adds the ability to refresh data in the GitHub plugin RHS sidebar, as requested in #131.

Two improvements:
1. **Auto-refresh on open** - When the RHS is opened, `getSidebarContent` is called automatically to guarantee the latest data is available.
2. **Manual refresh button** - A refresh icon (fa-refresh with tooltip) is added to the RHS header. Clicking it triggers `getSidebarContent` with a spinner animation while loading.

Resolves #131

## Changes
- `sidebar_right/index.jsx`: Wire `getSidebarContent` action to `SidebarRight`
- `sidebar_right/sidebar_right.jsx`: Add refresh state, handler, auto-refresh on mount, and refresh button in header

## Release Notes
```release-note
Added the ability to manually refresh and auto-refresh data in the GitHub RHS sidebar.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The work is isolated to the GitHub RHS refresh UX (wiring `getSidebarContent` and adding UI concurrency/unmount safety), but it introduces new async request timing and state transitions that can be sensitive to rapid user interactions and view switching.  
**Regression Risk:** Moderate due to potential race-condition edge cases (rapid opens/clicks, unmount during in-flight refresh), though the blast radius is limited to sidebar components and Redux action usage and there are targeted automated tests.  
**QA Recommendation:** Perform targeted manual QA for RHS open/view switch triggering refresh, manual refresh button spinner/tooltip behavior, concurrent/deduped refresh while pending, unmount/navigation during refresh, and correct PRs/reviews/unreads/assignments rendering on both light and dark themes; manual QA can be skipped only if the full automated suite is green and you’ve validated the specific refresh flows in a staging environment.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->