### PR TITLE
docs: add PULL_REQUEST_TEMPLATE.md for consistent PR descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+<!-- A clear, concise description of what this PR does. -->
+
+## Changes
+<!-- Bullet list of changes. Be specific about files/modules affected. -->
+
+## Ticket / Issue
+<!-- Link to related issue: Resolves #NNN or Related to #NNN -->
+
+## Release Notes
+<!-- 
+  For user-facing changes, include a release note:
+  ```release-note
+  Description of the change for the release notes.
+  ```
+  For non-user-facing changes (refactors, tests, docs):
+  ```release-note-none
+  ```
+-->
+
+## Screenshots
+<!-- If applicable, add screenshots or GIFs showing the change. -->
+
+## Testing
+<!-- How was this tested? Include manual testing steps and/or automated tests added. -->
+
+## Checklist
+- [ ] Changes follow the project's code style guidelines
+- [ ] Self-review completed
+- [ ] Documentation updated (if applicable)
+- [ ] New tests added (if applicable)
+- [ ] All existing tests pass
+- [ ] Release notes included (or `release-note-none`)


### PR DESCRIPTION
## Summary
Adds a `PULL_REQUEST_TEMPLATE.md` to standardize PR descriptions. Currently the plugin has no PR template, but reviewers consistently expect Summary, Changes, Release Notes, and a link to the related issue.

## Changes
- Added `.github/PULL_REQUEST_TEMPLATE.md` with sections:
  - Summary (what and why)
  - Changes (bullet list)
  - Ticket / Issue link (Resolves #NNN)
  - Release Notes (`release-note` or `release-note-none`)
  - Screenshots
  - Testing steps
  - Checklist

## Ticket / Issue
No specific issue — this is a developer experience improvement.

```release-note-none
```

## Testing
- Verified the template renders correctly on GitHub by creating a test PR from the fork
- Template follows Mattermost contribution patterns observed in existing PRs

## Checklist
- [x] Changes follow the project's code style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] New tests added (if applicable)
- [x] All existing tests pass
- [x] Release notes included (or `release-note-none`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a docs-only update that adds a pull request template and does not change runtime code, APIs, or shared logic. The blast radius is isolated to contributor workflow and has negligible regression potential.

**Regression Risk:** Very low; no application behavior, persistence, or critical paths are affected, and the change is limited to repository metadata used when creating PRs.

**QA Recommendation:** Manual QA is not required. A quick visual check on GitHub for template rendering is sufficient.
*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->