### PR TITLE
Don't DM the PR author for every inline comment in a submitted review

### DIFF
--- a/server/plugin/test_utils.go
+++ b/server/plugin/test_utils.go
@@ -303,6 +303,12 @@ func GetMockPullRequestReviewCommentEvent(action, body, sender string) *github.P
 	}
 }
 
+func GetMockPullRequestReviewCommentReplyEvent(action, body, sender string, replyTo int64) *github.PullRequestReviewCommentEvent {
+	event := GetMockPullRequestReviewCommentEvent(action, body, sender)
+	event.Comment.InReplyTo = github.Int64(replyTo)
+	return event
+}
+
 func GetMockIssueCommentEvent(action, body, sender string) *github.IssueCommentEvent {
 	return &github.IssueCommentEvent{
 		Action: github.String(action),

--- a/server/plugin/webhook.go
+++ b/server/plugin/webhook.go
@@ -1151,6 +1151,11 @@ func (p *Plugin) handleReviewCommentAuthorNotification(event *github.PullRequest
 		return
 	}
 
+	// Top-level comments on a submitted review are already DMed via handlePullRequestReviewNotification.
+	if event.GetComment().GetInReplyTo() == 0 {
+		return
+	}
+
 	authorUserID := p.getGitHubToUserIDMapping(author)
 	if authorUserID == "" {
 		return

--- a/server/plugin/webhook_test.go
+++ b/server/plugin/webhook_test.go
@@ -611,12 +611,17 @@ func TestHandleReviewCommentAuthorNotification(t *testing.T) {
 		},
 		{
 			name:  "Sender is the PR author",
-			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockIssueAuthor),
+			event: GetMockPullRequestReviewCommentReplyEvent(actionCreated, "body", MockIssueAuthor, 99),
+			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
+		},
+		{
+			name:  "Top-level review comment is covered by the review submitted notification",
+			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
 			setup: func(_ *plugintest.API, _ *mocks.MockKvStore) {},
 		},
 		{
 			name:  "Author not mapped to Mattermost",
-			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
+			event: GetMockPullRequestReviewCommentReplyEvent(actionCreated, "body", MockUserLogin, 99),
 			setup: func(_ *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockKVStore.EXPECT().Get("issueAuthor_githubusername", mock.MatchedBy(func(val any) bool {
 					_, ok := val.(*[]uint8)
@@ -625,8 +630,8 @@ func TestHandleReviewCommentAuthorNotification(t *testing.T) {
 			},
 		},
 		{
-			name:  "Successful author notification",
-			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
+			name:  "Successful author notification for thread reply",
+			event: GetMockPullRequestReviewCommentReplyEvent(actionCreated, "body", MockUserLogin, 99),
 			setup: func(mockAPI *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockKVStore.EXPECT().Get("issueAuthor_githubusername", mock.MatchedBy(func(val any) bool {
 					_, ok := val.(*[]uint8)
@@ -646,7 +651,7 @@ func TestHandleReviewCommentAuthorNotification(t *testing.T) {
 		},
 		{
 			name:  "Muted sender suppresses author notification",
-			event: GetMockPullRequestReviewCommentEvent(actionCreated, "body", MockUserLogin),
+			event: GetMockPullRequestReviewCommentReplyEvent(actionCreated, "body", MockUserLogin, 99),
 			setup: func(_ *plugintest.API, mockKVStore *mocks.MockKvStore) {
 				mockKVStore.EXPECT().Get("issueAuthor_githubusername", mock.MatchedBy(func(val any) bool {
 					_, ok := val.(*[]uint8)


### PR DESCRIPTION
#### Summary
- Submitting a GitHub review with multiple inline comments was sending the PR author one DM per comment, in addition to the existing review-submitted DM.
- That fan-out came from [#1010](https://github.com/mattermost/mattermost-plugin-github/pull/1010), which added author DMs for `pull_request_review_comment` events. GitHub emits one of those webhooks per inline comment when a review is submitted.
- Skip the author DM for top-level review comments (`in_reply_to_id` unset); those are already covered by `handlePullRequestReviewNotification`. Still DM for thread replies, and still notify on @mentions.

#### QA Notes
- Submit a review with several new inline comments (not replies): the PR author should get **one** GitHub-bot DM for the review, not one per comment.
- Reply on an existing review thread: the PR author should still get a DM for that reply.
- @mention someone who is not the PR author in an inline comment: they should still get a mention DM.
- Edit or delete a review comment: no new "commented" DM (existing #1010 behavior).

#### Release Note
```release-note
Fixed GitHub bot DMs so submitting a review with multiple inline comments notifies the PR author once instead of once per comment.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The change modifies user-facing notification behavior in the webhook handler. Tests cover top-level comments and thread replies, and the change has a narrow blast radius.

**Regression Risk:** Medium. Incorrect reply detection could suppress valid author notifications or create duplicate notifications. Existing tests cover the main paths.

** QA Recommendation:** Perform targeted manual QA for submitted reviews with top-level comments, thread replies, edited comments, deleted comments, and `@mentions`. Skipping manual QA presents a low-to-medium risk because automated coverage exists.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->