### PR TITLE
MM-70684 Update GitHub plugin for React 19 in Mattermost v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ To trigger a release, follow these steps:
 ### Playwright e2e tests
 
 In order to get your environment set up to run [Playwright](https://playwright.dev) tests, please see the setup guide at [e2e/playwright](/e2e/playwright#readme).
+
+### React 19 compatibility
+
+This plugin requires Mattermost 12.0 or later with the MM-70687 host JSX runtime exports. Webpack externalizes React, ReactDOM (including `react-dom/client`), and both JSX runtimes to the host globals. These mappings also cover runtime imports from dependencies. Rebuild the plugin after changing its configuration.

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-github",
     "support_url": "https://github.com/mattermost/mattermost-plugin-github/issues",
     "icon_path": "assets/icon.svg",
-    "min_server_version": "10.7.0",
+    "min_server_version": "12.0.0",
     "server": {
       "executables": {
           "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "webpack --mode=production",
     "build:watch": "webpack --mode=production --watch",
-    "debug": "webpack --mode=none",
+    "debug": "webpack --mode=development",
     "debug:watch": "webpack --mode=development --watch",
     "lint": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --cache",
     "fix": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx --ext tsx --ext ts . --quiet --fix --cache",

--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -175,7 +175,20 @@ export const LinkTooltip = ({href, connected, show, theme, enterpriseURL}) => {
                                 </p>
                             )}
                             <div className='markdown-text mt-1 mb-1'>
-                                <ReactMarkdown linkTarget='_blank'>{description}</ReactMarkdown>
+                                <ReactMarkdown
+                                    components={{a: ({href: url, children, title}) => (
+                                        <a
+                                            href={url}
+                                            title={title}
+                                            target='_blank'
+                                            rel='noopener noreferrer'
+                                        >
+                                            {children}
+                                        </a>
+                                    )}}
+                                >
+                                    {description}
+                                </ReactMarkdown>
                             </div>
 
                             {/* base <- head */}

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -89,6 +89,9 @@ module.exports = {
     externals: {
         react: 'React',
         'react-dom': 'ReactDOM',
+        'react-dom/client': 'ReactDOM',
+        'react/jsx-runtime': 'ReactJSXRuntime',
+        'react/jsx-dev-runtime': 'ReactJSXDevRuntime',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
#### Summary

Fixes the GitHub plugin startup crash on Mattermost v12 / React 19. The plugin already used the host's React, but dependencies could bundle React 18's JSX runtime. That older runtime accesses React internals such as `ReactCurrentOwner` that are no longer available in React 19, causing the plugin bundle to fail during startup.

Externalizes `react/jsx-runtime` and `react/jsx-dev-runtime` to `ReactJSXRuntime` and `ReactJSXDevRuntime`, keeping JSX helpers aligned with the host's React. Also maps `react-dom/client` to the host's ReactDOM, requires Mattermost 12.0.0, and sets the debug build to development mode. Requires the host exports from https://github.com/mattermost/mattermost/pull/38489.

Replaces react-markdown's removed `linkTarget` prop with a custom link renderer, preserving links opening in a new tab and fixing an existing tooltip-rendering failure.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70684

#### Release Note

```release-note
Updated the GitHub plugin for React 19 in Mattermost v12, fixing a startup crash caused by a bundled older JSX runtime. Raised the minimum supported Mattermost version to 12.0.0 and fixed Markdown tooltip rendering.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The changes affect plugin startup, Webpack dependency mapping, and Markdown link rendering. The scope is limited to the plugin, but compatibility depends on Mattermost v12 host exports.

**Regression Risk:** Medium. Incorrect external mappings or link rendering can cause startup failures or user-facing rendering issues.

**QA Recommendation:** Perform focused manual QA on plugin startup, debug builds, Markdown links, tooltips, and Mattermost v12 compatibility. Skipping manual QA has moderate risk.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->